### PR TITLE
Use javaxExtras instead of jsr305 and add package-info to java compilers

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -62,7 +62,7 @@ ext.deps = [
         appCompat: 'com.android.support:appcompat-v7:27.0.2',
         errorProneAnnotations: "com.google.errorprone:error_prone_annotations:${versions.errorProne}",
         javapoet: "com.squareup:javapoet:1.10.0",
-        jsr305: 'com.google.code.findbugs:jsr305:3.0.2',
+        javaxExtras: 'com.uber.javaxextras:javax-extras:0.1.0',
         kotlinMetadata: 'me.eugeniomarletti:kotlin-metadata:1.2.1',
         kotlinpoet: 'com.squareup:kotlinpoet:0.6.0',
         gson: "com.google.code.gson:gson:2.8.1",

--- a/integration-test/lib1/build.gradle
+++ b/integration-test/lib1/build.gradle
@@ -29,7 +29,7 @@ dependencies {
   annotationProcessor deps.apt.autoValueMoshi
   annotationProcessor project(":crumb-compiler")
   annotationProcessor project(":integration-test:compiler")
-  compileOnly deps.misc.jsr305
+  compileOnly deps.misc.javaxExtras
 
   api deps.apt.autoValueAnnotations
   api deps.misc.gson

--- a/integration-test/lib2/build.gradle
+++ b/integration-test/lib2/build.gradle
@@ -29,7 +29,7 @@ dependencies {
   annotationProcessor deps.apt.autoValueMoshi
   annotationProcessor project(":crumb-compiler")
   annotationProcessor project(":integration-test:compiler")
-  compileOnly deps.misc.jsr305
+  compileOnly deps.misc.javaxExtras
 
   api deps.apt.autoValueAnnotations
   api deps.misc.gson

--- a/integration-test/lib3/build.gradle
+++ b/integration-test/lib3/build.gradle
@@ -29,7 +29,7 @@ dependencies {
   annotationProcessor deps.apt.autoValueMoshi
   annotationProcessor project(":crumb-compiler")
   annotationProcessor project(":integration-test:compiler")
-  compileOnly deps.misc.jsr305
+  compileOnly deps.misc.javaxExtras
 
   implementation deps.apt.autoValueAnnotations
   api deps.misc.gson

--- a/sample/experiments-compiler/experiment-enums-compiler/java/build.gradle
+++ b/sample/experiments-compiler/experiment-enums-compiler/java/build.gradle
@@ -24,6 +24,7 @@ targetCompatibility = JavaVersion.VERSION_1_8
 
 dependencies {
   annotationProcessor deps.apt.autoService
+  compileOnly deps.misc.javaxExtras
 
   implementation deps.apt.autoService
   implementation deps.apt.autoCommon

--- a/sample/experiments-compiler/experiment-enums-compiler/java/src/main/java/com/uber/crumb/sample/experimentenumscompiler/package-info.java
+++ b/sample/experiments-compiler/experiment-enums-compiler/java/src/main/java/com/uber/crumb/sample/experimentenumscompiler/package-info.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2018. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@com.uber.javaxextras.EverythingIsNonNullByDefault
+package com.uber.crumb.sample.experimentenumscompiler;

--- a/sample/plugins-compiler/plugins-compiler/java/build.gradle
+++ b/sample/plugins-compiler/plugins-compiler/java/build.gradle
@@ -24,6 +24,7 @@ targetCompatibility = JavaVersion.VERSION_1_8
 
 dependencies {
   annotationProcessor deps.apt.autoService
+  compileOnly deps.misc.javaxExtras
 
   implementation deps.apt.autoService
   implementation deps.apt.autoCommon

--- a/sample/plugins-compiler/plugins-compiler/java/src/main/java/com/uber/crumb/sample/pluginscompiler/package-info.java
+++ b/sample/plugins-compiler/plugins-compiler/java/src/main/java/com/uber/crumb/sample/pluginscompiler/package-info.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2018. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@com.uber.javaxextras.EverythingIsNonNullByDefault
+package com.uber.crumb.sample.pluginscompiler;


### PR DESCRIPTION
These have always annoyed me in the IDE with the missing NonNull annotation errors
