### PR TITLE
Remove trailing whitespace from README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 Crumb
 =====
 
-Crumb is an annotation processor that exposes a simple and flexible API to breadcrumb  
-metadata across compilation boundaries. Working with dependencies manually is usually fine, but there's often 
-cases where developers will want to automatically gather and act on information from those dependencies (code 
+Crumb is an annotation processor that exposes a simple and flexible API to breadcrumb
+metadata across compilation boundaries. Working with dependencies manually is usually fine, but there's often
+cases where developers will want to automatically gather and act on information from those dependencies (code
 generation, gathering metrics, etc). Tools like `ServiceLoader` can solve some cases like this, but lack flexibility and
 can be slow at runtime.
 
 This is where Crumb comes in. Crumb's API is an annotation-based, consumer/producer system where extensions
-can opt in to consuming or producing metadata. Extensions run at compile-time to produce or consume this 
-metadata, while Crumb's processor manages this metadata for them (serializing, storing, retrieving, orchestrating the 
+can opt in to consuming or producing metadata. Extensions run at compile-time to produce or consume this
+metadata, while Crumb's processor manages this metadata for them (serializing, storing, retrieving, orchestrating the
 data to appropriate consumers, etc). This allows developers to propagate arbitrary data across compilation boundaries.
 
 Some example usages:
@@ -17,7 +17,7 @@ Some example usages:
   * Automatically gathering adapters for model serialization (such as `TypeAdapter`s for json serialization with Gson)
   * Automatic registration or reporting of experiments in feature libraries
   * Automatic registration of buildable components in a DI system, such as Dagger modules
-  
+
 More in-depth examples can be found at the bottom of this README.
 
 ## Download
@@ -38,10 +38,10 @@ Snapshots of the development version are available in [Sonatype's snapshots repo
 
 There are four annotations in the `crumb-annotations` artifact:
 
-`@CrumbProducer` - This annotation can be used on custom annotations to signal to the 
+`@CrumbProducer` - This annotation can be used on custom annotations to signal to the
 processor that elements annotated with the custom annotation are used to produce metadata.
 
-`@CrumbConsumer` - This annotation can be used on custom annotations to signal to the 
+`@CrumbConsumer` - This annotation can be used on custom annotations to signal to the
 processor that elements annotated with the custom annotation are used to consume metadata.
 
 `@CrumbQualifier` - This annotation can be used on custom annotations to indicate that elements
@@ -54,11 +54,11 @@ annotations they support).
 ### Extensions API
 
 There are two extension interfaces that follow a Producer/Consumer symmetry. The API (and compiler
-implementation) is in Kotlin, but seamlessly interoperable with Java. The API is SPI-based, so implementations can be 
+implementation) is in Kotlin, but seamlessly interoperable with Java. The API is SPI-based, so implementations can be
 wired up with something like [AutoService][autoservice].
 
 Both interfaces extend from a `CrumbExtension` base interface, that just has a method `key()`. This
-method has a default implementation in Kotlin that just returns the fully qualified class name of 
+method has a default implementation in Kotlin that just returns the fully qualified class name of
 the extension. This is used to key the extension name when storing and retrieving metadata.
 
 The API usually gives a `CrumbContext` instance when calling into extensions, which just contains
@@ -66,38 +66,38 @@ useful information like references to the `ProcessingEnvironment` or `RoundEnvir
 
 `CrumbProducerExtension` - This interface is used to declare a producer extension. These extensions
 are called into when a type is trying to produce metadata to write to the classpath. The API is:
-  * `supportedProducerAnnotations()` - Returns a set of supported annotations. Has a default 
+  * `supportedProducerAnnotations()` - Returns a set of supported annotations. Has a default
   implementation in Kotlin (empty), and is used to indicate to the compiler which annotations
-  should be included in processing (since annotation processors have to declared which annotations 
+  should be included in processing (since annotation processors have to declared which annotations
   they need).
   * `isProducerApplicable(context: CrumbContext, type: TypeElement, annotations: Collection<AnnotationMirror>` -
   Returns a boolean indicating whether or not this producer is applicable to a given type/annotations combination.
-  The `annotations` are any `@CrumbQualifier`-annotated annotations found on `type`. Extensions may use 
+  The `annotations` are any `@CrumbQualifier`-annotated annotations found on `type`. Extensions may use
   whatever signaling they see fit though.
   * `produce(context: CrumbContext, type: TypeElement, annotations: Collection<AnnotationMirror>` -
-  This is the call to produce metadata, and just returns a `Map<String, String>` (`typealias`'d in 
-  Kotlin to `ProducerMetadata`). Consumers can put whatever they want in this map (so be 
+  This is the call to produce metadata, and just returns a `Map<String, String>` (`typealias`'d in
+  Kotlin to `ProducerMetadata`). Consumers can put whatever they want in this map (so be
   responsible!). The `type` and `annotations` parameters are the same as from `isProducerApplicable()`.
 
 `CrumbConsumerExtension` - This interface is used to declare a consumer extension. These extensions
 are called into when a type is trying to consume metadata to from the classpath. The API is:
-  * `supportedConsumerAnnotations()` - Returns a set of supported annotations. Has a default 
+  * `supportedConsumerAnnotations()` - Returns a set of supported annotations. Has a default
   implementation in Kotlin (empty), and is used to indicate to the compiler which annotations
-  should be included in processing (since annotation processors have to declared which annotations 
+  should be included in processing (since annotation processors have to declared which annotations
   they need).
   * `isConsumerApplicable(context: CrumbContext, type: TypeElement, annotations: Collection<AnnotationMirror>` -
   Returns a boolean indicating whether or not this consumer is applicable to a given type/annotations combination.
-  The `annotations` are any `@CrumbQualifier`-annotated annotations found on `type`. Extensions may use 
+  The `annotations` are any `@CrumbQualifier`-annotated annotations found on `type`. Extensions may use
   whatever signaling they see fit though.
   * `consume(context: CrumbContext, type: TypeElement, annotations: Collection<AnnotationMirror>, metadata: Set<ConsumerMetadata>)` -
-  This is the call to consume metadata, and is given a `Set<Map<String, String>>` (`typealias`'d in 
-  Kotlin to `ConsumerMetadata`). This is a set of all `ProducerMetadata` maps discovered on the 
-  classpath returned for this extension's declared `key()`. The `type` and `annotations` parameters 
+  This is the call to consume metadata, and is given a `Set<Map<String, String>>` (`typealias`'d in
+  Kotlin to `ConsumerMetadata`). This is a set of all `ProducerMetadata` maps discovered on the
+  classpath returned for this extension's declared `key()`. The `type` and `annotations` parameters
   are the same as from `isConsumerApplicable()`.
 
 ## CrumbManager
 
-Crumb's core functionality can be leveraged independently from the `compiler` artifact via the 
+Crumb's core functionality can be leveraged independently from the `compiler` artifact via the
 `crumb-core` artifact. This can be useful for integration within existing tooling, and contains
 a `CrumbManager` and `CrumbLog` API. The `crumb-compiler` artifact is an advanced frontend
 over this utility.
@@ -107,7 +107,7 @@ with debugging issues.
 
 ## Packaging
 
-To exclude crumbs from being compiled into an Android application APK, add the following exclusion 
+To exclude crumbs from being compiled into an Android application APK, add the following exclusion
 via the `packagingOptions` closure:
 
 ```gradle
@@ -126,13 +126,13 @@ Note that this is only when consuming data in a plain Kotlin project. Android pr
 
 ## Example: Plugin Loader
 
-To demonstrate the functionality of Crumb, a real-world example must be used, a hypothetical plugin 
-system to automatically gather and instantiate implementations of the `Translations` interface from 
-downstream dependencies. Conceptually this is similar to a 
-[`ServiceLoader`](https://docs.oracle.com/javase/7/docs/api/java/util/ServiceLoader.html), but at 
+To demonstrate the functionality of Crumb, a real-world example must be used, a hypothetical plugin
+system to automatically gather and instantiate implementations of the `Translations` interface from
+downstream dependencies. Conceptually this is similar to a
+[`ServiceLoader`](https://docs.oracle.com/javase/7/docs/api/java/util/ServiceLoader.html), but at
 compile-time and with annotations.
 
-To prevent a traditional approach of manually loading the implementations, Crumb makes it possible to 
+To prevent a traditional approach of manually loading the implementations, Crumb makes it possible to
 automatically discover and utilize the `Translations` classes on the classpath.
 
 #### Producing metadata
@@ -147,7 +147,7 @@ public class EnglishTranslations implements Translations {
 
 The plugin implementation then needs to be registered into the plugin manager upstream. A Crumb
 extension can convey this information to consumers of the library by writing its
-location to Crumb and retrieving it on the other side. For this example, a custom `@Plugin` 
+location to Crumb and retrieving it on the other side. For this example, a custom `@Plugin`
 annotation is used to mark these translations implementations.
 
 ```java
@@ -155,8 +155,8 @@ annotation is used to mark these translations implementations.
 public @interface Plugin {}
 ```
 
-Note that it's annotated with `@CrumbProducer` so that the `CrumbProcessor` knows that this 
-`@Plugin` annotation is used to produce metadata. Now this annotation can be applied to the 
+Note that it's annotated with `@CrumbProducer` so that the `CrumbProcessor` knows that this
+`@Plugin` annotation is used to produce metadata. Now this annotation can be applied to the
 implementation class:
 
 ```java
@@ -166,29 +166,29 @@ public class EnglishTranslations implements Translations {
 }
 ```
 
-`@Plugin` is a custom annotation that the extension looks for in its `isProducerApplicable` 
-check. Any custom annotation could be used. Extensions also have direct access to the 
+`@Plugin` is a custom annotation that the extension looks for in its `isProducerApplicable`
+check. Any custom annotation could be used. Extensions also have direct access to the
 `TypeElement`, so other signaling choices would work as well.
 
-Now that the implementation is denoted via the `@Plugin` annotation, the next step is implementing 
+Now that the implementation is denoted via the `@Plugin` annotation, the next step is implementing
 the `ProducerExtension` for this:
 
 ```java
 @AutoService(ProducerExtension.class)
 public class PluginsCompiler implements ProducerExtension {
-  
+
   @Override
   public String key() {
     return "PluginsCompiler";
   }
-  
+
   @Override
   public boolean isProducerApplicable(CrumbContext context,
       TypeElement type,
       Collection<AnnotationMirror> annotations) {
     // Check for the @Plugin annotation here
   }
-  
+
   @Override
   public Map<String, String> produce(CrumbContext context,
       TypeElement type,
@@ -200,19 +200,19 @@ public class PluginsCompiler implements ProducerExtension {
 }
 ```
 
-Crumb will take the returned metadata and make it available to any extension that 
-also declared the key returned by `key()`. 
-  * `context` is a holder class with access to the current `ProcessingEnvironment` and 
+Crumb will take the returned metadata and make it available to any extension that
+also declared the key returned by `key()`.
+  * `context` is a holder class with access to the current `ProcessingEnvironment` and
   `RoundEnvironment`
   * `type` is the `@CrumbProducer`-annotated type (`EnglishTranslations`)
-  * `annotations` are the `@CrumbQualifier`-annotated annotations found on that `type`. For 
+  * `annotations` are the `@CrumbQualifier`-annotated annotations found on that `type`. For
   simplicity, all holders are required to have a static `obtain()` method.
 
 #### Consuming metadata
 
 For the consumer side, our example will have a top-level `TranslationsPluginManager` class that just delegates to
 discovered downstream translations. With a `ConsumerExtension`, downstream services can be consumed
-and codegen'd directly with JavaPoet. For simplicity, this manager will follow an auto-value style 
+and codegen'd directly with JavaPoet. For simplicity, this manager will follow an auto-value style
 pattern of having an abstract class with the generated implementation as a subclass.
 
 The desired API looks like this:
@@ -227,7 +227,7 @@ public abstract class TranslationsPluginManager {
 }
 ```
 
-Crumb can be wired in here. The symmetric counterpart to `@CrumbProducer` is `@CrumbConsumer`, so 
+Crumb can be wired in here. The symmetric counterpart to `@CrumbProducer` is `@CrumbConsumer`, so
 this example uses a similar `@PluginPoint` annotation here for consuming. This time it's annotated
 with `@CrumbConsumer` to indicate that it's for consumption.
 
@@ -253,34 +253,34 @@ public abstract class TranslationsPluginManager {
 }
 ```
 
-This is all the information needed for the `ConsumerExtension`. Implementation of it looks like 
+This is all the information needed for the `ConsumerExtension`. Implementation of it looks like
 this:
 
 ```java
 @AutoService(ConsumerExtension.class)
 public class PluginsCompiler implements ConsumerExtension {
-  
+
   @Override
   public String key() {
     return "PluginsCompiler";
   }
-  
+
   @Override
   public boolean isConsumerApplicable(CrumbContext context,
       TypeElement type,
       Collection<AnnotationMirror> annotations) {
     // Check for the PluginPoint annotation here
   }
-  
+
   @Override
   public void consume(CrumbContext context,
       TypeElement type,
       Collection<AnnotationMirror> annotations,
       Set<Map<String, String>> metadata) {
     // Each map is an instance of the Map we returned in the producer above
-    
+
     PluginPoint targetPlugin = type.getAnnotation(PluginPoint.class).value(); // Not how it actually works, but here for readability
-    
+
     // List of plugin TypeElements
     ImmutableSet<TypeElement> pluginClasses =
         metadata
@@ -297,14 +297,14 @@ public class PluginsCompiler implements ConsumerExtension {
                     .getTypeUtils()
                     .isAssignable(pluginType.asType(), targetPlugin))
             .collect(toImmutableSet());
-    
-    // pluginClasses contains a set of all downstream plugin type implementations. This 
+
+    // pluginClasses contains a set of all downstream plugin type implementations. This
   }
 }
 ```
 
-This closes the loop from the producers to the consumer. `pluginClasses` contains a set of all 
-downstream plugin type implementations and could leverage `JavaPoet` to generate a backing 
+This closes the loop from the producers to the consumer. `pluginClasses` contains a set of all
+downstream plugin type implementations and could leverage `JavaPoet` to generate a backing
 implementation that looks like this:
 
 ```java
@@ -317,8 +317,8 @@ public final class Plugins_TranslationsPluginManager extends TranslationsPluginM
 }
 ```
 
-Note that both extension examples are called `PluginsCompiler`. Each interface is fully 
-interoperable with the other, so it's possible to make one extension that implements both interfaces for 
+Note that both extension examples are called `PluginsCompiler`. Each interface is fully
+interoperable with the other, so it's possible to make one extension that implements both interfaces for
 code sharing.
 
 ```java
@@ -328,7 +328,7 @@ public class PluginsCompiler implements ProducerExtension, ConsumerExtension {
 }
 ```
 
-The complete implemented version of this example can be found under the `:sample:plugins-compiler` 
+The complete implemented version of this example can be found under the `:sample:plugins-compiler`
 directory.
 
 There's also an example `experiments-compiler` demonstrating how to trace enum-denoted experiments


### PR DESCRIPTION
No need for the trailing whitespace.