### PR TITLE
Update dependencies and modify CrumbManager for new element-based API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: android
 
+dist: trusty
+
 jdk:
   - openjdk8
   - openjdk11

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ language: android
 dist: trusty
 
 jdk:
-  - openjdk8
-  - openjdk11
+  - oraclejdk8
 
 before_install:
   # Install SDK license so Android Gradle plugin can install deps.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: android
 
 jdk:
-  - oraclejdk8
+  - openjdk8
+  - openjdk11
 
 before_install:
   # Install SDK license so Android Gradle plugin can install deps.

--- a/README.md
+++ b/README.md
@@ -109,14 +109,9 @@ Full docs can be found here: https://uber.github.io/crumb/0.x/
 
 ## Packaging
 
-To exclude crumbs from being compiled into an Android application APK, add the following exclusion
-via the `packagingOptions` closure:
-
-```gradle
-packagingOptions {
-  exclude "META-INF/com.uber.crumb/**"
-}
-```
+Crumb works via generating synthetic types that hold `@CrumbIndex` annotations that hold information. These
+must be present in consumers compilation classpath to be used, but can be safely stripped (via 
+tools such as R8, Proguard, etc) in production applications as they should appear to be unused.
 
 ## Kotlin Issues
 

--- a/README.md
+++ b/README.md
@@ -113,14 +113,6 @@ Crumb works via generating synthetic types that hold `@CrumbIndex` annotations t
 must be present in consumers compilation classpath to be used, but can be safely stripped (via 
 tools such as R8, Proguard, etc) in production applications as they should appear to be unused.
 
-## Kotlin Issues
-
-There is one issue we've encountered when using this in plain Kotlin Gradle projects:
-
-[Resources in project dependencies are not available in consuming projects](https://youtrack.jetbrains.com/issue/KT-23724)
-
-Note that this is only when consuming data in a plain Kotlin project. Android projects work fine.
-
 ## Example: Plugin Loader
 
 To demonstrate the functionality of Crumb we will have a hypothetical plugin

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,19 @@
  * limitations under the License.
  */
 
+buildscript {
+  apply from: 'gradle/dependencies.gradle'
+  repositories {
+    mavenCentral()
+    jcenter()
+    google()
+  }
+  dependencies {
+    classpath deps.build.gradlePlugins.android
+    classpath deps.build.gradlePlugins.kotlin
+  }
+}
+
 plugins {
   id 'com.diffplug.gradle.spotless'
 }

--- a/crumb-annotations/src/main/java/com/uber/crumb/annotations/internal/CrumbIndex.java
+++ b/crumb-annotations/src/main/java/com/uber/crumb/annotations/internal/CrumbIndex.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.uber.crumb.annotations.internal;
 
 import java.lang.annotation.Retention;

--- a/crumb-annotations/src/main/java/com/uber/crumb/annotations/internal/CrumbIndex.java
+++ b/crumb-annotations/src/main/java/com/uber/crumb/annotations/internal/CrumbIndex.java
@@ -1,0 +1,17 @@
+package com.uber.crumb.annotations.internal;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+
+/**
+ * An annotation for recording information about a given index in crumb. Should be considered
+ * private API.
+ */
+@Retention(RetentionPolicy.CLASS)
+@Target(TYPE)
+public @interface CrumbIndex {
+  String value();
+}

--- a/crumb-compiler-api/build.gradle
+++ b/crumb-compiler-api/build.gradle
@@ -31,8 +31,8 @@ dependencies {
   kapt deps.apt.autoService
   compileOnly deps.apt.autoServiceAnnotations
 
-  compile deps.kotlin.stdLibJdk8
-  compile project(":crumb-annotations")
+  api deps.kotlin.stdLibJdk8
+  api project(":crumb-annotations")
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/crumb-compiler/build.gradle
+++ b/crumb-compiler/build.gradle
@@ -30,12 +30,13 @@ dependencies {
   kapt deps.apt.autoService
   compileOnly deps.apt.autoServiceAnnotations
 
+  api deps.misc.moshi
+  api project(":crumb-core")
+  api project(':crumb-compiler-api')
+
   implementation deps.apt.autoCommon
-  implementation deps.misc.moshi
   implementation deps.kotlin.stdLibJdk8
-  implementation project(":crumb-core")
   implementation project(":crumb-annotations")
-  implementation project(':crumb-compiler-api')
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/crumb-compiler/build.gradle
+++ b/crumb-compiler/build.gradle
@@ -28,6 +28,7 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
 
 dependencies {
   kapt deps.apt.autoService
+  kapt deps.apt.moshiKotlinCodegen
   compileOnly deps.apt.autoServiceAnnotations
 
   api deps.misc.moshi

--- a/crumb-compiler/build.gradle
+++ b/crumb-compiler/build.gradle
@@ -30,12 +30,12 @@ dependencies {
   kapt deps.apt.autoService
   compileOnly deps.apt.autoServiceAnnotations
 
-  compile deps.apt.autoCommon
-  compile deps.misc.moshi
-  compile deps.kotlin.stdLibJdk8
-  compile project(":crumb-core")
-  compile project(":crumb-annotations")
-  compile project(':crumb-compiler-api')
+  implementation deps.apt.autoCommon
+  implementation deps.misc.moshi
+  implementation deps.kotlin.stdLibJdk8
+  implementation project(":crumb-core")
+  implementation project(":crumb-annotations")
+  implementation project(':crumb-compiler-api')
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/crumb-compiler/build.gradle
+++ b/crumb-compiler/build.gradle
@@ -13,9 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-import org.gradle.internal.jvm.Jvm
-
 plugins {
   id 'org.jetbrains.kotlin.jvm'
   id 'org.jetbrains.kotlin.kapt'
@@ -39,8 +36,6 @@ dependencies {
   compile project(":crumb-core")
   compile project(":crumb-annotations")
   compile project(':crumb-compiler-api')
-
-  compileOnly files(Jvm.current().getToolsJar())
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/crumb-compiler/src/main/kotlin/com/uber/crumb/CrumbProcessor.kt
+++ b/crumb-compiler/src/main/kotlin/com/uber/crumb/CrumbProcessor.kt
@@ -216,10 +216,13 @@ class CrumbProcessor : AbstractProcessor {
           // Write metadata to resources for consumers to pick up
           val crumbModel = CrumbModel("$packageName.$adapterName", globalExtras)
           val json = crumbAdapter.toJson(crumbModel)
-          crumbManager.store(CRUMB_INDICES_PACKAGE,
-              "$adapterName$CRUMB_INDEX_SUFFIX",
-              json,
-              CrumbOutputLanguage.languageForType(producer))
+          crumbManager.store(
+              packageName = CRUMB_INDICES_PACKAGE,
+              fileName = "$adapterName$CRUMB_INDEX_SUFFIX",
+              dataToWrite = json,
+              outputLanguage = CrumbOutputLanguage.languageForType(producer),
+              originatingElements = setOf(producer)
+          )
         }
   }
 

--- a/crumb-compiler/src/main/kotlin/com/uber/crumb/CrumbProcessor.kt
+++ b/crumb-compiler/src/main/kotlin/com/uber/crumb/CrumbProcessor.kt
@@ -292,7 +292,7 @@ class CrumbProcessor : AbstractProcessor {
 }
 
 @Suppress("UNCHECKED_CAST", "NOTHING_TO_INLINE")
-internal inline fun <T> Iterable<*>.cast() = map { it as T }
+private inline fun <T> Iterable<*>.cast() = map { it as T }
 
 @JsonClass(generateAdapter = true)
 internal data class CrumbModel(

--- a/crumb-core/build.gradle
+++ b/crumb-core/build.gradle
@@ -13,9 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-import org.gradle.internal.jvm.Jvm
-
 plugins {
   id 'org.jetbrains.kotlin.jvm'
   id 'org.jetbrains.dokka'
@@ -30,7 +27,6 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
 
 dependencies {
   compile deps.kotlin.stdLibJdk8
-  compileOnly files(Jvm.current().getToolsJar())
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/crumb-core/build.gradle
+++ b/crumb-core/build.gradle
@@ -26,7 +26,10 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
 }
 
 dependencies {
+  api project(":crumb-annotations")
   compile deps.kotlin.stdLibJdk8
+  implementation deps.misc.javapoet
+  implementation deps.misc.kotlinpoet
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/crumb-core/build.gradle
+++ b/crumb-core/build.gradle
@@ -27,7 +27,7 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
 
 dependencies {
   api project(":crumb-annotations")
-  compile deps.kotlin.stdLibJdk8
+  api deps.kotlin.stdLibJdk8
   implementation deps.misc.javapoet
   implementation deps.misc.kotlinpoet
 }

--- a/crumb-core/src/main/kotlin/com/uber/crumb/core/CrumbManager.kt
+++ b/crumb-core/src/main/kotlin/com/uber/crumb/core/CrumbManager.kt
@@ -13,36 +13,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-@file:Suppress("UNCHECKED_CAST")
-
 package com.uber.crumb.core
 
 import com.uber.crumb.annotations.internal.CrumbIndex
-import java.io.Serializable
 import javax.annotation.processing.ProcessingEnvironment
 import javax.lang.model.element.Element
 import javax.lang.model.element.PackageElement
 
 /**
- * // TODO new docs
- * A utility class that helps adding build specific objects to the jar file and their extraction later on. This
- * specifically works by reading/writing metadata in the Crumb `META-INF` location of jars from the classpath.
+ * A utility class that helps with generating types to hold [CrumbIndexes][CrumbIndex] of metadata and reading them
+ * later.
  *
- * Optionally, a colon-delimited list of extra locations to search for in loading can be specified via specifying the
- * [OPTION_EXTRA_LOCATIONS] option in the given [env].
- *
- * Adapted from the [Android DataBinding library](https://android.googlesource.com/platform/frameworks/data-binding/+/master).
+ * @property env A given [ProcessingEnvironment] instance.
+ * @property crumbLog A [CrumbLog] instance for logging information.
  */
 class CrumbManager(private val env: ProcessingEnvironment,
     private val crumbLog: CrumbLog) {
 
   /**
-   * This loads a given [Set]<[T]> from the Crumb `META-INF` store that matches the given [nameFilter].
+   * This loads a given [Set]<String> from the available [CrumbIndex] instances in the given [packageName].
    *
-   * @param nameFilter a name filter to match on. Conventionally, one could use a "known" file extension used for file
-   *                   names in [store].
-   * @return the loaded [Set]<[T]>, or an empty set if none were found.
+   * @param packageName The target package to load types containing [CrumbIndex] annotations from.
+   * @return the loaded [Set]<String>, or an empty set if none were found.
    */
   fun load(packageName: String): Set<String> {
     // If this package is null, it means there are no classes with this package name. One way this
@@ -62,11 +54,15 @@ class CrumbManager(private val env: ProcessingEnvironment,
   }
 
   /**
-   * This writes a given [String] [dataToWrite] to the Crumb `META-INF` store.
+   * This writes a given [String] [dataToWrite] to a [CrumbIndex] type in the given [packageName].
    *
-   * @param packageName the package name to use for the file in writing.
-   * @param fileName the file name to use in writing.
-   * @param dataToWrite the [Serializable] object to write.
+   * @param packageName The package name to use for the file in writing. Note that this should be the package that all
+   *                    metadata index-holder types are written to, and not necessarily the package name of the source
+   *                    element.
+   * @param fileName The file name to use in writing.
+   * @param dataToWrite The metadata to write to the eventual [CrumbIndex].
+   * @param outputLanguage The target output language.
+   * @param originatingElements Any originating elements for the metadata.
    */
   fun store(
       packageName: String,

--- a/crumb-core/src/main/kotlin/com/uber/crumb/core/CrumbManager.kt
+++ b/crumb-core/src/main/kotlin/com/uber/crumb/core/CrumbManager.kt
@@ -21,6 +21,7 @@ package com.uber.crumb.core
 import com.uber.crumb.annotations.internal.CrumbIndex
 import java.io.Serializable
 import javax.annotation.processing.ProcessingEnvironment
+import javax.lang.model.element.Element
 import javax.lang.model.element.PackageElement
 
 /**
@@ -71,7 +72,8 @@ class CrumbManager(private val env: ProcessingEnvironment,
       packageName: String,
       fileName: String,
       dataToWrite: String,
-      outputLanguage: CrumbOutputLanguage) {
-    outputLanguage.writeTo(env.filer, packageName, fileName, dataToWrite)
+      outputLanguage: CrumbOutputLanguage,
+      originatingElements: Set<Element> = emptySet()) {
+    outputLanguage.writeTo(env.filer, packageName, fileName, dataToWrite, originatingElements)
   }
 }

--- a/crumb-core/src/main/kotlin/com/uber/crumb/core/CrumbManager.kt
+++ b/crumb-core/src/main/kotlin/com/uber/crumb/core/CrumbManager.kt
@@ -18,23 +18,13 @@
 
 package com.uber.crumb.core
 
-import com.sun.tools.javac.processing.JavacProcessingEnvironment
-import com.uber.crumb.core.CrumbManager.Companion.OPTION_EXTRA_LOCATIONS
-import java.io.File
-import java.io.IOException
-import java.io.InputStream
-import java.io.ObjectInputStream
-import java.io.ObjectOutputStream
+import com.uber.crumb.annotations.internal.CrumbIndex
 import java.io.Serializable
-import java.net.URISyntaxException
-import java.net.URL
-import java.net.URLClassLoader
-import java.util.zip.ZipFile
 import javax.annotation.processing.ProcessingEnvironment
-import javax.tools.JavaFileManager
-import javax.tools.StandardLocation
+import javax.lang.model.element.PackageElement
 
 /**
+ * // TODO new docs
  * A utility class that helps adding build specific objects to the jar file and their extraction later on. This
  * specifically works by reading/writing metadata in the Crumb `META-INF` location of jars from the classpath.
  *
@@ -46,14 +36,6 @@ import javax.tools.StandardLocation
 class CrumbManager(private val env: ProcessingEnvironment,
     private val crumbLog: CrumbLog) {
 
-  companion object {
-    /**
-     * A colon-delimited list of extra locations to search in loading.
-     */
-    const val OPTION_EXTRA_LOCATIONS = "crumb.options.extraLocations"
-    private const val CRUMB_PREFIX = "META-INF/com.uber.crumb/"
-  }
-
   /**
    * This loads a given [Set]<[T]> from the Crumb `META-INF` store that matches the given [nameFilter].
    *
@@ -61,128 +43,35 @@ class CrumbManager(private val env: ProcessingEnvironment,
    *                   names in [store].
    * @return the loaded [Set]<[T]>, or an empty set if none were found.
    */
-  @Throws(IOException::class)
-  fun <T : Serializable> load(nameFilter: (String) -> Boolean): Set<T> {
-    val fileManager = (env as JavacProcessingEnvironment).context.get(JavaFileManager::class.java)
-    val classLoader = fileManager.getClassLoader(StandardLocation.CLASS_PATH)
-    check(classLoader is URLClassLoader) {
-      "Classloader must be an instance of URLClassLoader. $classLoader"
+  fun load(packageName: String): Set<String> {
+    // If this package is null, it means there are no classes with this package name. One way this
+    // could happen is if we process an annotation and reach this point without writing something
+    // to the package. We do not error check here because that shouldn't happen with the
+    // current implementation.
+    val crumbGenPackage: PackageElement? = env.elementUtils.getPackageElement(packageName)
+
+    if (crumbGenPackage == null) {
+      crumbLog.e("No @CrumbIndex-annotated elements found in $packageName")
+      return emptySet()
     }
 
-    val urlClassLoader = classLoader as URLClassLoader
-    val objects = mutableSetOf<T>()
-    val extraLocations = env.options[OPTION_EXTRA_LOCATIONS]
-        ?.split(":")
-        ?.map { URL("file:$it") }
-        ?: emptyList()
-    for (url in (urlClassLoader.urLs + extraLocations)) {
-      crumbLog.d("Checking url %s for Crumb data", url)
-      try {
-        val file = File(url.toURI())
-        if (!file.exists()) {
-          crumbLog.d("Cannot load file for %s", url)
-          continue
-        }
-        if (file.isDirectory) {
-          // probably exported classes dir.
-          loadFromDirectory(nameFilter, file, objects)
-        } else {
-          // assume it is a zip file
-          loadFomZipFile(nameFilter, file, objects)
-        }
-      } catch (e: IOException) {
-        crumbLog.d("Cannot open zip file from %s", url)
-      } catch (e: URISyntaxException) {
-        crumbLog.d("Cannot open zip file from %s", url)
-      }
+    return crumbGenPackage.enclosedElements.mapNotNullTo(mutableSetOf()) { element ->
+      element.getAnnotation(CrumbIndex::class.java)?.value
     }
-    return objects
-  }
-
-  @Throws(IOException::class)
-  private fun <T : Serializable> loadFromDirectory(nameFilter: (String) -> Boolean,
-      from: File,
-      into: MutableSet<T>) {
-    from.walkTopDown()
-        .filter { nameFilter(it.name) }
-        .forEach { file ->
-          try {
-            file.inputStream().use {
-              try {
-                val item = fromInputStream(it)
-                item?.let {
-                  into += (item as T)
-                  crumbLog.d("Loaded item %s from file", item)
-                }
-              } catch (e: IOException) {
-                crumbLog.e(e, "Could not merge in crumbs from %s", file.absolutePath)
-              }
-            }
-          } catch (e: ClassNotFoundException) {
-            crumbLog.e(e, "Could not read Crumb file. %s",
-                file.absolutePath)
-          }
-        }
-  }
-
-  @Throws(IOException::class)
-  private fun <T : Serializable> loadFomZipFile(nameFilter: (String) -> Boolean,
-      from: File,
-      into: MutableSet<T>) {
-    val zipFile = ZipFile(from)
-    zipFile.entries()
-        .asSequence()
-        .filter { nameFilter(it.name) }
-        .forEach { entry ->
-          try {
-            zipFile.getInputStream(entry).use {
-              try {
-                val item = fromInputStream(it)
-                crumbLog.d("loaded item $item from zip file")
-                item?.let {
-                  into += (item as T)
-                }
-              } catch (e: IOException) {
-                crumbLog.e(e, "Could not merge in Crumb file from %s", from.absolutePath)
-              }
-            }
-          } catch (e: ClassNotFoundException) {
-            crumbLog.e(e, "Could not read Crumb file. %s", from.absolutePath)
-          }
-        }
-  }
-
-  @Throws(IOException::class, ClassNotFoundException::class)
-  private fun fromInputStream(inputStream: InputStream): Serializable? {
-    ObjectInputStream(inputStream).use { return it.readObject() as Serializable }
   }
 
   /**
-   * This writes a given [Serializable] [objectToWrite] to the Crumb `META-INF` store.
+   * This writes a given [String] [dataToWrite] to the Crumb `META-INF` store.
    *
    * @param packageName the package name to use for the file in writing.
    * @param fileName the file name to use in writing.
-   * @param objectToWrite the [Serializable] object to write.
+   * @param dataToWrite the [Serializable] object to write.
    */
-  @Throws(IOException::class)
   fun store(
       packageName: String,
       fileName: String,
-      objectToWrite: Serializable) {
-    try {
-      env.filer.createResource(
-          StandardLocation.CLASS_OUTPUT,
-          "",
-          "$CRUMB_PREFIX$packageName/$fileName")
-          .openOutputStream()
-          .use { ios ->
-            ObjectOutputStream(ios).use { oos ->
-              oos.writeObject(objectToWrite)
-              crumbLog.d("Wrote Crumb file %s %s", packageName, fileName)
-            }
-          }
-    } catch (e: IOException) {
-      crumbLog.e(e, "Could not write to Crumb file: %s", fileName)
-    }
+      dataToWrite: String,
+      outputLanguage: CrumbOutputLanguage) {
+    outputLanguage.writeTo(env.filer, packageName, fileName, dataToWrite)
   }
 }

--- a/crumb-core/src/main/kotlin/com/uber/crumb/core/CrumbOutputLanguage.kt
+++ b/crumb-core/src/main/kotlin/com/uber/crumb/core/CrumbOutputLanguage.kt
@@ -29,6 +29,9 @@ import javax.lang.model.element.Modifier.FINAL
 import javax.lang.model.element.Modifier.PRIVATE
 import javax.lang.model.element.TypeElement
 
+private typealias KotlinTypeSpec = com.squareup.kotlinpoet.TypeSpec
+private typealias KotlinAnnotationSpec = com.squareup.kotlinpoet.AnnotationSpec
+
 /**
  * TODO doc
  * TODO explanatory comments in code
@@ -53,8 +56,8 @@ enum class CrumbOutputLanguage {
           }
           .build()
       JavaFile.builder(packageName, typeSpec)
-          .addFileComment("Generated, do not modify!")
-          .indent("  ")
+          .addFileComment(GENERATED_COMMENT)
+          .indent(INDENT)
           .build()
           .writeTo(filer)
     }
@@ -67,8 +70,8 @@ enum class CrumbOutputLanguage {
         dataToWrite: String,
         originatingElements: Set<Element>
     ) {
-      val typeSpec = com.squareup.kotlinpoet.TypeSpec.objectBuilder(fileName)
-          .addAnnotation(com.squareup.kotlinpoet.AnnotationSpec.builder(CrumbIndex::class)
+      val typeSpec = KotlinTypeSpec.objectBuilder(fileName)
+          .addAnnotation(KotlinAnnotationSpec.builder(CrumbIndex::class)
               .addMember("%S", dataToWrite)
               .build())
           .addModifiers(KModifier.PRIVATE)
@@ -77,9 +80,9 @@ enum class CrumbOutputLanguage {
           }
           .build()
       FileSpec.builder(packageName, fileName)
-          .addComment("Generated, do not modify!")
+          .addComment(GENERATED_COMMENT)
           .addType(typeSpec)
-          .indent("  ")
+          .indent(INDENT)
           .build()
           .writeTo(filer)
     }
@@ -93,6 +96,8 @@ enum class CrumbOutputLanguage {
   )
 
   companion object {
+    private const val GENERATED_COMMENT = "Generated, do not modify!"
+    private const val INDENT = "  "
     fun languageForType(element: TypeElement): CrumbOutputLanguage {
       return if (element.getAnnotation(Metadata::class.java) != null) {
         KOTLIN

--- a/crumb-core/src/main/kotlin/com/uber/crumb/core/CrumbOutputLanguage.kt
+++ b/crumb-core/src/main/kotlin/com/uber/crumb/core/CrumbOutputLanguage.kt
@@ -34,7 +34,6 @@ private typealias KotlinAnnotationSpec = com.squareup.kotlinpoet.AnnotationSpec
 
 /**
  * TODO doc
- * TODO explanatory comments in code
  */
 enum class CrumbOutputLanguage {
   JAVA {
@@ -46,6 +45,7 @@ enum class CrumbOutputLanguage {
         originatingElements: Set<Element>
     ) {
       val typeSpec = TypeSpec.classBuilder(fileName)
+          .addJavadoc(EXPLANATORY_COMMENT)
           .addAnnotation(AnnotationSpec.builder(CrumbIndex::class.java)
               .addMember("value", "\$S", dataToWrite)
               .build())
@@ -71,6 +71,7 @@ enum class CrumbOutputLanguage {
         originatingElements: Set<Element>
     ) {
       val typeSpec = KotlinTypeSpec.objectBuilder(fileName)
+          .addKdoc(EXPLANATORY_COMMENT)
           .addAnnotation(KotlinAnnotationSpec.builder(CrumbIndex::class)
               .addMember("%S", dataToWrite)
               .build())
@@ -96,6 +97,7 @@ enum class CrumbOutputLanguage {
   )
 
   companion object {
+    private const val EXPLANATORY_COMMENT = "This type + annotation exists for sharing information to the Crumb annotation processor and should not be considered public API."
     private const val GENERATED_COMMENT = "Generated, do not modify!"
     private const val INDENT = "  "
     fun languageForType(element: TypeElement): CrumbOutputLanguage {

--- a/crumb-core/src/main/kotlin/com/uber/crumb/core/CrumbOutputLanguage.kt
+++ b/crumb-core/src/main/kotlin/com/uber/crumb/core/CrumbOutputLanguage.kt
@@ -1,0 +1,79 @@
+package com.uber.crumb.core
+
+import com.squareup.javapoet.AnnotationSpec
+import com.squareup.javapoet.JavaFile
+import com.squareup.javapoet.MethodSpec
+import com.squareup.javapoet.TypeSpec
+import com.squareup.kotlinpoet.FileSpec
+import com.squareup.kotlinpoet.KModifier
+import com.uber.crumb.annotations.internal.CrumbIndex
+import javax.annotation.processing.Filer
+import javax.lang.model.element.Modifier.FINAL
+import javax.lang.model.element.Modifier.PRIVATE
+import javax.lang.model.element.TypeElement
+
+/**
+ * TODO doc
+ * TODO explanatory comments in code
+ * TODO originating elements
+ */
+enum class CrumbOutputLanguage {
+  JAVA {
+    override fun writeTo(
+        filer: Filer,
+        packageName: String,
+        fileName: String,
+        dataToWrite: String
+    ) {
+      val typeSpec = TypeSpec.classBuilder(fileName)
+          .addAnnotation(AnnotationSpec.builder(CrumbIndex::class.java)
+              .addMember("value", dataToWrite)
+              .build())
+          .addModifiers(FINAL)
+          .addMethod(MethodSpec.constructorBuilder().addModifiers(PRIVATE).build())
+          .build()
+      JavaFile.builder(packageName, typeSpec)
+          .addFileComment("Generated, do not modify!")
+          .indent("  ")
+          .build()
+          .writeTo(filer)
+    }
+  },
+  KOTLIN {
+    override fun writeTo(
+        filer: Filer,
+        packageName: String,
+        fileName: String,
+        dataToWrite: String
+    ) {
+      val typeSpec = com.squareup.kotlinpoet.TypeSpec.objectBuilder(fileName)
+          .addAnnotation(com.squareup.kotlinpoet.AnnotationSpec.builder(CrumbIndex::class)
+              .addMember("", dataToWrite)
+              .build())
+          .addModifiers(KModifier.PRIVATE)
+          .build()
+      FileSpec.builder(packageName, fileName)
+          .addComment("Generated, do not modify!")
+          .addType(typeSpec)
+          .indent("  ")
+          .build()
+          .writeTo(filer)
+    }
+  };
+
+  abstract fun writeTo(filer: Filer,
+      packageName: String,
+      fileName: String,
+      dataToWrite: String
+  )
+
+  companion object {
+    fun languageForType(element: TypeElement): CrumbOutputLanguage {
+      return if (element.getAnnotation(Metadata::class.java) != null) {
+        KOTLIN
+      } else {
+        JAVA
+      }
+    }
+  }
+}

--- a/crumb-core/src/main/kotlin/com/uber/crumb/core/CrumbOutputLanguage.kt
+++ b/crumb-core/src/main/kotlin/com/uber/crumb/core/CrumbOutputLanguage.kt
@@ -33,7 +33,8 @@ private typealias KotlinTypeSpec = com.squareup.kotlinpoet.TypeSpec
 private typealias KotlinAnnotationSpec = com.squareup.kotlinpoet.AnnotationSpec
 
 /**
- * TODO doc
+ * Supported output languages for Crumb metadata. When [writeTo] is called, a simple empty class is generated to hold a
+ * [CrumbIndex] annotation containing all the crumb metadata specified.
  */
 enum class CrumbOutputLanguage {
   JAVA {
@@ -89,6 +90,16 @@ enum class CrumbOutputLanguage {
     }
   };
 
+  /**
+   * Writes crumb metadata for this language.
+   *
+   * @param filer A [Filer] to write with.
+   * @param packageName The package to write to. Note that this should be the package that all metadata index-holder
+   *                    types are written to, and not necessarily the package name of the source element.
+   * @param fileName The file name.
+   * @param dataToWrite The metadata to write to the eventual [CrumbIndex].
+   * @param originatingElements Any originating elements for the metadata.
+   */
   abstract fun writeTo(filer: Filer,
       packageName: String,
       fileName: String,
@@ -100,6 +111,11 @@ enum class CrumbOutputLanguage {
     private const val EXPLANATORY_COMMENT = "This type + annotation exists for sharing information to the Crumb annotation processor and should not be considered public API."
     private const val GENERATED_COMMENT = "Generated, do not modify!"
     private const val INDENT = "  "
+
+    /**
+     * @return the target language that should be used for a given [element]. In principle, this tries to match the
+     * output language to the source language.
+     */
     fun languageForType(element: TypeElement): CrumbOutputLanguage {
       return if (element.getAnnotation(Metadata::class.java) != null) {
         KOTLIN

--- a/crumb-core/src/main/kotlin/com/uber/crumb/core/CrumbOutputLanguage.kt
+++ b/crumb-core/src/main/kotlin/com/uber/crumb/core/CrumbOutputLanguage.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2019. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uber.crumb.core
 
 import com.squareup.javapoet.AnnotationSpec

--- a/crumb-core/src/main/kotlin/com/uber/crumb/core/CrumbOutputLanguage.kt
+++ b/crumb-core/src/main/kotlin/com/uber/crumb/core/CrumbOutputLanguage.kt
@@ -43,7 +43,7 @@ enum class CrumbOutputLanguage {
     ) {
       val typeSpec = TypeSpec.classBuilder(fileName)
           .addAnnotation(AnnotationSpec.builder(CrumbIndex::class.java)
-              .addMember("value", dataToWrite)
+              .addMember("value", "\$S", dataToWrite)
               .build())
           .addModifiers(FINAL)
           .addMethod(MethodSpec.constructorBuilder().addModifiers(PRIVATE).build())
@@ -64,7 +64,7 @@ enum class CrumbOutputLanguage {
     ) {
       val typeSpec = com.squareup.kotlinpoet.TypeSpec.objectBuilder(fileName)
           .addAnnotation(com.squareup.kotlinpoet.AnnotationSpec.builder(CrumbIndex::class)
-              .addMember("", dataToWrite)
+              .addMember("%S", dataToWrite)
               .build())
           .addModifiers(KModifier.PRIVATE)
           .build()

--- a/gradle.properties
+++ b/gradle.properties
@@ -29,3 +29,4 @@ POM_DEVELOPER_NAME=Uber Technologies
 
 android.enableSeparateAnnotationProcessing=true
 android.suppressUnsupportedOptionWarnings=android.suppressUnsupportedOptionWarnings,android.enableSeparateAnnotationProcessing
+kapt.includeCompileClasspath = false'

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,5 +27,5 @@ POM_LICENCE_DIST=repo
 POM_DEVELOPER_ID=uber
 POM_DEVELOPER_NAME=Uber Technologies
 
-# Not supported on AGP with gradle 4.6+
-org.gradle.configureondemand=false
+android.enableSeparateAnnotationProcessing=true
+android.suppressUnsupportedOptionWarnings=android.suppressUnsupportedOptionWarnings,android.enableSeparateAnnotationProcessing

--- a/gradle.properties
+++ b/gradle.properties
@@ -29,4 +29,4 @@ POM_DEVELOPER_NAME=Uber Technologies
 
 android.enableSeparateAnnotationProcessing=true
 android.suppressUnsupportedOptionWarnings=android.suppressUnsupportedOptionWarnings,android.enableSeparateAnnotationProcessing
-kapt.includeCompileClasspath = false'
+kapt.includeCompileClasspath=false

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -38,7 +38,7 @@ ext.deps = [
         autoValueAnnotations: "com.google.auto.value:auto-value-annotations:${versions.autoValue}",
         autoValueGson: "com.ryanharter.auto.value:auto-value-gson:${versions.autoValueGson}",
         autoValueGsonRuntime: "com.ryanharter.auto.value:auto-value-gson-runtime:${versions.autoValueGson}",
-        autoValueMoshi: "com.ryanharter.auto.value:auto-value-moshi:0.4.6",
+        autoValueMoshi: "com.ryanharter.auto.value:auto-value-moshi:0.4.4",
     ],
 
     build: [

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -38,7 +38,7 @@ ext.deps = [
         autoValueAnnotations: "com.google.auto.value:auto-value-annotations:${versions.autoValue}",
         autoValueGson: "com.ryanharter.auto.value:auto-value-gson:${versions.autoValueGson}",
         autoValueGsonRuntime: "com.ryanharter.auto.value:auto-value-gson-runtime:${versions.autoValueGson}",
-        autoValueMoshi: "com.ryanharter.auto.value:auto-value-moshi:0.4.4",
+        autoValueMoshi: "com.ryanharter.auto.value:auto-value-moshi:0.4.7",
     ],
 
     build: [

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -15,16 +15,16 @@
  */
 
 def versions = [
-    autoService: '1.0-rc5',
-    autoValue: '1.6.3',
+    autoService: '1.0-rc6',
+    autoValue: '1.6.5',
     autoValueGson: '1.0.0',
     errorProne: '2.3.3',
     dokka: '0.9.18',
     errorPronePlugin: '0.7.1',
     gjf: '1.7',
-    kotlin: '1.3.21',
-    ktlint: '0.31.0',
-    spotless: '3.20.0'
+    kotlin: '1.3.41',
+    ktlint: '0.34.2',
+    spotless: '3.24.0'
 ]
 
 ext.deps = [
@@ -38,7 +38,7 @@ ext.deps = [
         autoValueAnnotations: "com.google.auto.value:auto-value-annotations:${versions.autoValue}",
         autoValueGson: "com.ryanharter.auto.value:auto-value-gson:${versions.autoValueGson}",
         autoValueGsonRuntime: "com.ryanharter.auto.value:auto-value-gson-runtime:${versions.autoValueGson}",
-        autoValueMoshi: "com.ryanharter.auto.value:auto-value-moshi:0.4.4",
+        autoValueMoshi: "com.ryanharter.auto.value:auto-value-moshi:0.4.6",
     ],
 
     build: [
@@ -50,7 +50,7 @@ ext.deps = [
         errorProne: "com.google.errorprone:error_prone_core:${versions.errorProne}",
 
         gradlePlugins: [
-            android: 'com.android.tools.build:gradle:3.3.2',
+            android: 'com.android.tools.build:gradle:3.4.1',
             dokka: "org.jetbrains.dokka:dokka-gradle-plugin:${versions.dokka}",
             dokkaAndroid: "org.jetbrains.dokka:dokka-android-gradle-plugin:${versions.dokka}",
             kotlin: "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
@@ -69,20 +69,20 @@ ext.deps = [
         javapoet: "com.squareup:javapoet:1.11.1",
         javaxExtras: 'com.uber.javaxextras:javax-extras:0.1.0',
         kotlinMetadata: 'me.eugeniomarletti.kotlin.metadata:kotlin-metadata:1.4.0',
-        kotlinpoet: 'com.squareup:kotlinpoet:1.1.0',
+        kotlinpoet: 'com.squareup:kotlinpoet:1.3.0',
         gson: "com.google.code.gson:gson:2.8.5",
-        guava: "com.google.guava:guava:27.1-jre",
+        guava: "com.google.guava:guava:28.0-jre",
         moshi: "com.squareup.moshi:moshi:1.8.0",
     ],
 
     rx: [
         android: 'io.reactivex.rxjava2:rxandroid:2.1.1',
-        java: 'io.reactivex.rxjava2:rxjava:2.2.7'
+        java: 'io.reactivex.rxjava2:rxjava:2.2.11'
     ],
 
     test: [
-        compileTesting: 'com.google.testing.compile:compile-testing:0.15',
+        compileTesting: 'com.google.testing.compile:compile-testing:0.18',
         junit: 'junit:junit:4.12',
-        truth: 'com.google.truth:truth:0.43'
+        truth: 'com.google.truth:truth:1.0'
     ]
 ]

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -24,6 +24,7 @@ def versions = [
     gjf: '1.7',
     kotlin: '1.3.41',
     ktlint: '0.34.2',
+    moshi: '1.8.0',
     spotless: '3.24.0'
 ]
 
@@ -39,6 +40,7 @@ ext.deps = [
         autoValueGson: "com.ryanharter.auto.value:auto-value-gson:${versions.autoValueGson}",
         autoValueGsonRuntime: "com.ryanharter.auto.value:auto-value-gson-runtime:${versions.autoValueGson}",
         autoValueMoshi: "com.ryanharter.auto.value:auto-value-moshi:0.4.7",
+        moshiKotlinCodegen: "com.squareup.moshi:moshi-kotlin-codegen:${versions.moshi}",
     ],
 
     build: [
@@ -72,7 +74,7 @@ ext.deps = [
         kotlinpoet: 'com.squareup:kotlinpoet:1.3.0',
         gson: "com.google.code.gson:gson:2.8.5",
         guava: "com.google.guava:guava:28.0-jre",
-        moshi: "com.squareup.moshi:moshi:1.8.0",
+        moshi: "com.squareup.moshi:moshi:${versions.moshi}",
     ],
 
     rx: [

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.5.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -7,7 +7,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -5,7 +5,7 @@
 @rem you may not use this file except in compliance with the License.
 @rem You may obtain a copy of the License at
 @rem
-@rem      http://www.apache.org/licenses/LICENSE-2.0
+@rem      https://www.apache.org/licenses/LICENSE-2.0
 @rem
 @rem Unless required by applicable law or agreed to in writing, software
 @rem distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/compiler/build.gradle
+++ b/integration-test/compiler/build.gradle
@@ -41,4 +41,5 @@ dependencies {
 
   testImplementation project(":crumb-compiler")
   testImplementation deps.test.compileTesting
+  testImplementation files(org.gradle.internal.jvm.Jvm.current().getToolsJar())
 }

--- a/integration-test/compiler/build.gradle
+++ b/integration-test/compiler/build.gradle
@@ -13,9 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-import org.gradle.internal.jvm.Jvm
-
 plugins {
   id 'java-library'
   id 'org.jetbrains.kotlin.jvm'
@@ -42,8 +39,6 @@ dependencies {
   compile project(":crumb-compiler-api")
   compile project(":integration-test:annotations")
 
-  compileOnly files(Jvm.current().getToolsJar())
   testCompile project(":crumb-compiler")
   testCompile deps.test.compileTesting
-  testCompile files(Jvm.current().getToolsJar())
 }

--- a/integration-test/compiler/build.gradle
+++ b/integration-test/compiler/build.gradle
@@ -29,16 +29,16 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
 dependencies {
   kapt deps.apt.autoService
 
-  compile deps.apt.autoServiceAnnotations
-  compile deps.apt.autoCommon
-  compile deps.misc.guava
-  compile deps.misc.javapoet
-  compile deps.misc.gson
-  compile deps.misc.moshi
-  compile deps.kotlin.stdLibJdk8
-  compile project(":crumb-compiler-api")
-  compile project(":integration-test:annotations")
+  implementation deps.apt.autoServiceAnnotations
+  implementation deps.apt.autoCommon
+  implementation deps.misc.guava
+  implementation deps.misc.javapoet
+  implementation deps.misc.gson
+  implementation deps.misc.moshi
+  implementation deps.kotlin.stdLibJdk8
+  implementation project(":crumb-compiler-api")
+  implementation project(":integration-test:annotations")
 
-  testCompile project(":crumb-compiler")
-  testCompile deps.test.compileTesting
+  testImplementation project(":crumb-compiler")
+  testImplementation deps.test.compileTesting
 }

--- a/integration-test/integration/build.gradle
+++ b/integration-test/integration/build.gradle
@@ -34,7 +34,7 @@ dependencies {
   api project(":integration-test:lib3")
   api project(":integration-test:annotations")
 
-  testCompile deps.test.truth
+  testImplementation deps.test.truth
 
   errorprone "com.google.errorprone:error_prone_core:${deps.versions.errorProne}"
   //noinspection GradleDynamicVersion

--- a/integration-test/integration/src/test/java/com/uber/crumb/integration/consumer/IntegrationConsumerTest.java
+++ b/integration-test/integration/src/test/java/com/uber/crumb/integration/consumer/IntegrationConsumerTest.java
@@ -15,9 +15,6 @@
  */
 package com.uber.crumb.integration.consumer;
 
-import static com.google.common.truth.Truth.assertThat;
-import static junit.framework.TestCase.fail;
-
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.squareup.moshi.Moshi;
@@ -29,6 +26,9 @@ import com.uber.crumb.integration.lib3.Lib3Enum;
 import com.uber.crumb.integration.lib3.Lib3Model;
 import java.io.IOException;
 import org.junit.Test;
+
+import static com.google.common.truth.Truth.assertThat;
+import static junit.framework.TestCase.fail;
 
 public final class IntegrationConsumerTest {
 
@@ -97,7 +97,7 @@ public final class IntegrationConsumerTest {
         .isInstanceOf(Lib1Model.jsonAdapter(moshi).getClass());
   }
 
-  public static class TestData {
+  public static final class TestData {
 
     public final Lib1Model lib1Model;
     public final Lib1Enum lib1Enum;

--- a/integration-test/lib1/build.gradle
+++ b/integration-test/lib1/build.gradle
@@ -41,7 +41,7 @@ dependencies {
   api project(":crumb-annotations")
   api project(":integration-test:annotations")
 
-  testCompile deps.test.truth
+  testImplementation deps.test.truth
 
   errorprone "com.google.errorprone:error_prone_core:${deps.versions.errorProne}"
   //noinspection GradleDynamicVersion

--- a/integration-test/lib2/build.gradle
+++ b/integration-test/lib2/build.gradle
@@ -41,7 +41,7 @@ dependencies {
   api project(":crumb-annotations")
   api project(":integration-test:annotations")
 
-  testCompile deps.test.truth
+  testImplementation deps.test.truth
 
   errorprone "com.google.errorprone:error_prone_core:${deps.versions.errorProne}"
   //noinspection GradleDynamicVersion

--- a/integration-test/lib3/build.gradle
+++ b/integration-test/lib3/build.gradle
@@ -41,7 +41,7 @@ dependencies {
   api project(":crumb-annotations")
   api project(":integration-test:annotations")
 
-  testCompile deps.test.truth
+  testImplementation deps.test.truth
 
   errorprone "com.google.errorprone:error_prone_core:${deps.versions.errorProne}"
   //noinspection GradleDynamicVersion

--- a/sample/experiments-compiler/experiment-enums-compiler/annotations/build.gradle
+++ b/sample/experiments-compiler/experiment-enums-compiler/annotations/build.gradle
@@ -23,7 +23,7 @@ sourceCompatibility = JavaVersion.VERSION_1_7
 targetCompatibility = JavaVersion.VERSION_1_7
 
 dependencies {
-  compile project(':crumb-annotations')
+  api project(':crumb-annotations')
 
   errorprone "com.google.errorprone:error_prone_core:${deps.versions.errorProne}"
   //noinspection GradleDynamicVersion

--- a/sample/experiments-compiler/experiment-enums-compiler/java/build.gradle
+++ b/sample/experiments-compiler/experiment-enums-compiler/java/build.gradle
@@ -31,7 +31,7 @@ dependencies {
   implementation deps.misc.guava
   implementation deps.misc.javapoet
   implementation deps.kotlin.stdLibJdk8
-  implementation project(":crumb-compiler-api")
+  implementation project(path: ":crumb-compiler-api", configuration: "default")
   api project(":sample:experiments-compiler:experiment-enums-compiler:annotations")
 
   errorprone "com.google.errorprone:error_prone_core:${deps.versions.errorProne}"

--- a/sample/experiments-compiler/experiment-enums-compiler/kotlin/build.gradle
+++ b/sample/experiments-compiler/experiment-enums-compiler/kotlin/build.gradle
@@ -29,12 +29,12 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
 dependencies {
   kapt deps.apt.autoService
 
-  compile deps.apt.autoServiceAnnotations
-  compile deps.apt.autoCommon
-  compile deps.misc.guava
-  compile deps.misc.kotlinMetadata
-  compile deps.misc.kotlinpoet
-  compile deps.kotlin.stdLibJdk8
-  compile project(":crumb-compiler")
-  compile project(":sample:experiments-compiler:experiment-enums-compiler:annotations")
+  implementation deps.apt.autoServiceAnnotations
+  implementation deps.apt.autoCommon
+  implementation deps.misc.guava
+  implementation deps.misc.kotlinMetadata
+  implementation deps.misc.kotlinpoet
+  implementation deps.kotlin.stdLibJdk8
+  implementation project(":crumb-compiler")
+  implementation project(":sample:experiments-compiler:experiment-enums-compiler:annotations")
 }

--- a/sample/experiments-compiler/jvm/kotlin/app/build.gradle
+++ b/sample/experiments-compiler/jvm/kotlin/app/build.gradle
@@ -30,7 +30,7 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
 dependencies {
   kapt project(":crumb-compiler")
   kapt project(":sample:experiments-compiler:experiment-enums-compiler:kotlin")
-  compile project(":crumb-annotations")
-  compile project(":sample:experiments-compiler:jvm:kotlin:library")
-  compile deps.kotlin.stdLib
+  implementation project(":crumb-annotations")
+  implementation project(":sample:experiments-compiler:jvm:kotlin:library")
+  implementation deps.kotlin.stdLib
 }

--- a/sample/experiments-compiler/jvm/kotlin/library/build.gradle
+++ b/sample/experiments-compiler/jvm/kotlin/library/build.gradle
@@ -30,6 +30,6 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
 dependencies {
   kapt project(":crumb-compiler")
   kapt project(":sample:experiments-compiler:experiment-enums-compiler:kotlin")
-  compile project(":crumb-annotations")
-  compile project(":sample:experiments-compiler:experiment-enums-compiler:annotations")
+  api project(":crumb-annotations")
+  api project(":sample:experiments-compiler:experiment-enums-compiler:annotations")
 }

--- a/sample/plugins-compiler/jvm/kotlin/app/build.gradle
+++ b/sample/plugins-compiler/jvm/kotlin/app/build.gradle
@@ -30,8 +30,8 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
 dependencies {
   kapt project(":crumb-compiler")
   kapt project(":sample:plugins-compiler:plugins-compiler:kotlin")
-  compile project(":crumb-annotations")
-  compile project(":sample:plugins-compiler:jvm:kotlin:library")
-  compile project(":sample:plugins-compiler:translations-api")
-  compile deps.kotlin.stdLib
+  implementation project(":crumb-annotations")
+  implementation project(":sample:plugins-compiler:jvm:kotlin:library")
+  implementation project(":sample:plugins-compiler:translations-api")
+  implementation deps.kotlin.stdLib
 }

--- a/sample/plugins-compiler/jvm/kotlin/library/build.gradle
+++ b/sample/plugins-compiler/jvm/kotlin/library/build.gradle
@@ -30,8 +30,8 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
 dependencies {
   kapt project(":crumb-compiler")
   kapt project(":sample:plugins-compiler:plugins-compiler:kotlin")
-  compile deps.kotlin.stdLib
-  compile project(":crumb-annotations")
-  compile project(":sample:plugins-compiler:plugins-compiler:annotations")
-  compile project(":sample:plugins-compiler:translations-api")
+  implementation deps.kotlin.stdLib
+  api project(":crumb-annotations")
+  api project(":sample:plugins-compiler:plugins-compiler:annotations")
+  api project(":sample:plugins-compiler:translations-api")
 }

--- a/sample/plugins-compiler/plugins-compiler/annotations/build.gradle
+++ b/sample/plugins-compiler/plugins-compiler/annotations/build.gradle
@@ -23,7 +23,7 @@ sourceCompatibility = JavaVersion.VERSION_1_7
 targetCompatibility = JavaVersion.VERSION_1_7
 
 dependencies {
-  compile project(':crumb-annotations')
+  api project(':crumb-annotations')
 
   errorprone "com.google.errorprone:error_prone_core:${deps.versions.errorProne}"
   //noinspection GradleDynamicVersion

--- a/sample/plugins-compiler/plugins-compiler/java/build.gradle
+++ b/sample/plugins-compiler/plugins-compiler/java/build.gradle
@@ -31,7 +31,7 @@ dependencies {
   implementation deps.misc.guava
   implementation deps.misc.javapoet
   implementation deps.kotlin.stdLibJdk8
-  implementation project(":crumb-compiler-api")
+  implementation project(path: ":crumb-compiler-api", configuration: "default")
   api project(":sample:plugins-compiler:plugins-compiler:annotations")
 
   errorprone "com.google.errorprone:error_prone_core:${deps.versions.errorProne}"

--- a/sample/plugins-compiler/plugins-compiler/kotlin/build.gradle
+++ b/sample/plugins-compiler/plugins-compiler/kotlin/build.gradle
@@ -29,12 +29,12 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
 dependencies {
   kapt deps.apt.autoService
 
-  compile deps.apt.autoServiceAnnotations
-  compile deps.apt.autoCommon
-  compile deps.misc.guava
-  compile deps.misc.kotlinMetadata
-  compile deps.misc.kotlinpoet
-  compile deps.kotlin.stdLibJdk8
-  compile project(":crumb-compiler")
-  compile project(":sample:plugins-compiler:plugins-compiler:annotations")
+  implementation deps.apt.autoServiceAnnotations
+  implementation deps.apt.autoCommon
+  implementation deps.misc.guava
+  implementation deps.misc.kotlinMetadata
+  implementation deps.misc.kotlinpoet
+  implementation deps.kotlin.stdLibJdk8
+  implementation project(":crumb-compiler")
+  implementation project(":sample:plugins-compiler:plugins-compiler:annotations")
 }


### PR DESCRIPTION
This adopts Glide's style of sharing metadata by generating holder element with a new `@CrumbIndex` annotation that holds the serialized data. This isn't as opaque as the resources implementation, but it's safer version (avoids classpath conflicts), friendly to proguard removal, and most importantly unlocks supporting incremental annotation processing (#33).

Opportunistically updated dependencies along the way and using modern api/implementation configurations.

Other notes:
- Will generate java or kotlin depending on the source class
- Classes are basically (best-effort) inaccessible 
- Will implement full incremental apt support in a separate PR after this