### PR TITLE
Switch to using raw bytes for serialized format

### DIFF
--- a/crumb-annotations/src/main/java/com/uber/crumb/annotations/internal/CrumbIndex.java
+++ b/crumb-annotations/src/main/java/com/uber/crumb/annotations/internal/CrumbIndex.java
@@ -28,5 +28,6 @@ import static java.lang.annotation.ElementType.TYPE;
 @Retention(RetentionPolicy.CLASS)
 @Target(TYPE)
 public @interface CrumbIndex {
+  // TODO(zsweers) Maybe use a bytearray? Mirroring Kotlin's metadata annotations and they use String
   String value();
 }

--- a/crumb-annotations/src/main/java/com/uber/crumb/annotations/internal/CrumbIndex.java
+++ b/crumb-annotations/src/main/java/com/uber/crumb/annotations/internal/CrumbIndex.java
@@ -28,6 +28,6 @@ import static java.lang.annotation.ElementType.TYPE;
 @Retention(RetentionPolicy.CLASS)
 @Target(TYPE)
 public @interface CrumbIndex {
-  // TODO(zsweers) Maybe use a bytearray? Mirroring Kotlin's metadata annotations and they use String
+  // TODO(zsweers) Maybe use a bytearray? Mirroring Kotlin's metadata annotations & they use String
   String value();
 }

--- a/crumb-compiler/src/main/kotlin/com/uber/crumb/CrumbProcessor.kt
+++ b/crumb-compiler/src/main/kotlin/com/uber/crumb/CrumbProcessor.kt
@@ -52,8 +52,6 @@ import javax.tools.Diagnostic
 import javax.tools.Diagnostic.Kind.ERROR
 import javax.tools.Diagnostic.Kind.WARNING
 
-internal typealias MoshiTypes = com.squareup.moshi.Types
-
 /**
  * Processes all [CrumbConsumer] and [CrumbProducer] annotated types.
  */

--- a/crumb-core/build.gradle
+++ b/crumb-core/build.gradle
@@ -27,6 +27,7 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
 
 dependencies {
   api project(":crumb-annotations")
+  api deps.misc.okio
   api deps.kotlin.stdLibJdk8
   implementation deps.misc.javapoet
   implementation deps.misc.kotlinpoet

--- a/crumb-core/src/main/kotlin/com/uber/crumb/core/CrumbOutputLanguage.kt
+++ b/crumb-core/src/main/kotlin/com/uber/crumb/core/CrumbOutputLanguage.kt
@@ -23,6 +23,7 @@ import com.squareup.javapoet.TypeSpec
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.KModifier
 import com.uber.crumb.annotations.internal.CrumbIndex
+import okio.BufferedSource
 import javax.annotation.processing.Filer
 import javax.lang.model.element.Element
 import javax.lang.model.element.Modifier.FINAL
@@ -42,13 +43,13 @@ enum class CrumbOutputLanguage {
         filer: Filer,
         packageName: String,
         fileName: String,
-        dataToWrite: String,
+        dataToWrite: BufferedSource,
         originatingElements: Set<Element>
     ) {
       val typeSpec = TypeSpec.classBuilder(fileName)
           .addJavadoc(EXPLANATORY_COMMENT)
           .addAnnotation(AnnotationSpec.builder(CrumbIndex::class.java)
-              .addMember("value", "\$S", dataToWrite)
+              .addMember("value", "\$S", dataToWrite.readUtf8())
               .build())
           .addModifiers(FINAL)
           .addMethod(MethodSpec.constructorBuilder().addModifiers(PRIVATE).build())
@@ -68,13 +69,13 @@ enum class CrumbOutputLanguage {
         filer: Filer,
         packageName: String,
         fileName: String,
-        dataToWrite: String,
+        dataToWrite: BufferedSource,
         originatingElements: Set<Element>
     ) {
       val typeSpec = KotlinTypeSpec.objectBuilder(fileName)
           .addKdoc(EXPLANATORY_COMMENT)
           .addAnnotation(KotlinAnnotationSpec.builder(CrumbIndex::class)
-              .addMember("%S", dataToWrite)
+              .addMember("%S", dataToWrite.readUtf8())
               .build())
           .addModifiers(KModifier.PRIVATE)
           .apply {
@@ -103,7 +104,7 @@ enum class CrumbOutputLanguage {
   abstract fun writeTo(filer: Filer,
       packageName: String,
       fileName: String,
-      dataToWrite: String,
+      dataToWrite: BufferedSource,
       originatingElements: Set<Element> = emptySet()
   )
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -75,7 +75,7 @@ ext.deps = [
         gson: "com.google.code.gson:gson:2.8.5",
         guava: "com.google.guava:guava:28.0-jre",
         moshi: "com.squareup.moshi:moshi:${versions.moshi}",
-        okio: "com.squareup.okio:okio:2.3.0",
+        okio: "com.squareup.okio:okio:2.2.0",
     ],
 
     rx: [

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -75,6 +75,7 @@ ext.deps = [
         gson: "com.google.code.gson:gson:2.8.5",
         guava: "com.google.guava:guava:28.0-jre",
         moshi: "com.squareup.moshi:moshi:${versions.moshi}",
+        okio: "com.squareup.okio:okio:2.3.0",
     ],
 
     rx: [


### PR DESCRIPTION
This is a step toward #40, while also allowing flexible storage of arbitrary data. This uses Okio for the API. We may want to use a `byte[]` directly in the `@CrumbIndex` annotation later (left a footnote), but want to find out why Kotlin doesn't do that with its `@Metadata` annotations already first.