### PR TITLE
Implement support for incremental annotation processing

### DIFF
--- a/crumb-compiler-api/build.gradle
+++ b/crumb-compiler-api/build.gradle
@@ -23,7 +23,7 @@ plugins {
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
   kotlinOptions {
     jvmTarget = "1.8"
-    freeCompilerArgs = ['-Xjsr305=strict']
+    freeCompilerArgs = ['-Xjsr305=strict', '-Xjvm-default=enable']
   }
 }
 

--- a/crumb-compiler-api/src/main/kotlin/com/uber/crumb/compiler/api/CrumbConsumerExtension.kt
+++ b/crumb-compiler-api/src/main/kotlin/com/uber/crumb/compiler/api/CrumbConsumerExtension.kt
@@ -18,6 +18,8 @@ package com.uber.crumb.compiler.api
 
 import com.uber.crumb.annotations.CrumbConsumer
 import com.uber.crumb.annotations.CrumbQualifier
+import com.uber.crumb.compiler.api.CrumbExtension.IncrementalExtensionType
+import javax.annotation.processing.ProcessingEnvironment
 import javax.lang.model.element.AnnotationMirror
 import javax.lang.model.element.TypeElement
 
@@ -60,4 +62,20 @@ interface CrumbConsumerExtension : CrumbExtension {
       type: TypeElement,
       annotations: Collection<AnnotationMirror>,
       metadata: Set<ConsumerMetadata>)
+
+  /**
+   * Determines the incremental type of this Extension.
+   *
+   * The [ProcessingEnvironment] can be used, among other things, to obtain the processor
+   * options, using [ProcessingEnvironment.getOptions].
+   *
+   * The actual incremental type of the Crumb processor as a whole will be the loosest
+   * incremental types of the Extensions present in the annotation processor path. The default
+   * returned value is [IncrementalExtensionType.UNKNOWN], which will disable incremental
+   * annotation processing entirely.
+   */
+  @JvmDefault
+  fun consumerIncrementalType(processingEnvironment: ProcessingEnvironment): IncrementalExtensionType {
+    return IncrementalExtensionType.UNKNOWN
+  }
 }

--- a/crumb-compiler-api/src/main/kotlin/com/uber/crumb/compiler/api/CrumbExtension.kt
+++ b/crumb-compiler-api/src/main/kotlin/com/uber/crumb/compiler/api/CrumbExtension.kt
@@ -30,4 +30,41 @@ interface CrumbExtension {
     return javaClass.name
   }
 
+  /**
+   * Indicates to an annotation processor environment supporting incremental annotation processing
+   * (currently a feature specific to Gradle starting with version 4.8) the incremental type of an
+   * Extension.
+   *
+   * The constants for this enum are ordered by increasing performance (but also constraints).
+   *
+   * @see [Gradle documentation of its incremental annotation processing](https://docs.gradle.org/current/userguide/java_plugin.html.sec:incremental_annotation_processing)
+   */
+  enum class IncrementalExtensionType {
+    /**
+     * The incrementality of this extension is unknown, or it is neither aggregating nor isolating.
+     */
+    UNKNOWN,
+
+    /**
+     * This extension is *aggregating*, meaning that it may generate outputs based on several
+     * annotated input classes and it respects the constraints imposed on aggregating processors.
+     * It is common for Crumb producer extensions to be aggregating and unusual for consumer
+     * extensions to be aggregating.
+     *
+     * @see [Gradle definition of aggregating processors](https://docs.gradle.org/current/userguide/java_plugin.html.aggregating_annotation_processors)
+     */
+    AGGREGATING,
+
+    /**
+     * This extension is *isolating*, meaning roughly that its output depends on the
+     * `@CrumbConsumer`/`@CrumbProducer` class and its dependencies, but not on other `@CrumbConsumer`/`@CrumbProducer`
+     * classes that might be compiled at the same time. The constraints that an isolating extension must
+     * respect are the same as those that Gradle imposes on an isolating annotation processor.
+     * It is unusual for Crumb producer extensions to be isolating and common for consumer
+     * extensions to be isolating.
+     *
+     * @see [Gradle definition of isolating processors](https://docs.gradle.org/current/userguide/java_plugin.html.isolating_annotation_processors)
+     */
+    ISOLATING
+  }
 }

--- a/crumb-compiler-api/src/main/kotlin/com/uber/crumb/compiler/api/CrumbProducerExtension.kt
+++ b/crumb-compiler-api/src/main/kotlin/com/uber/crumb/compiler/api/CrumbProducerExtension.kt
@@ -18,6 +18,8 @@ package com.uber.crumb.compiler.api
 
 import com.uber.crumb.annotations.CrumbProducer
 import com.uber.crumb.annotations.CrumbQualifier
+import com.uber.crumb.compiler.api.CrumbExtension.IncrementalExtensionType
+import javax.annotation.processing.ProcessingEnvironment
 import javax.lang.model.element.AnnotationMirror
 import javax.lang.model.element.TypeElement
 
@@ -59,5 +61,21 @@ interface CrumbProducerExtension : CrumbExtension {
   fun produce(context: CrumbContext,
       type: TypeElement,
       annotations: Collection<AnnotationMirror>): ProducerMetadata
+
+  /**
+   * Determines the incremental type of this Extension.
+   *
+   * The [ProcessingEnvironment] can be used, among other things, to obtain the processor
+   * options, using [ProcessingEnvironment.getOptions].
+   *
+   * The actual incremental type of the Crumb processor as a whole will be the loosest
+   * incremental types of the Extensions present in the annotation processor path. The default
+   * returned value is [IncrementalExtensionType.UNKNOWN], which will disable incremental
+   * annotation processing entirely.
+   */
+  @JvmDefault
+  fun producerIncrementalType(processingEnvironment: ProcessingEnvironment): IncrementalExtensionType {
+    return IncrementalExtensionType.UNKNOWN
+  }
 
 }

--- a/crumb-compiler-api/src/main/kotlin/com/uber/crumb/compiler/api/CrumbTypeAliases.kt
+++ b/crumb-compiler-api/src/main/kotlin/com/uber/crumb/compiler/api/CrumbTypeAliases.kt
@@ -16,6 +16,8 @@
 
 package com.uber.crumb.compiler.api
 
+import javax.lang.model.element.Element
+
 typealias ExtensionKey = String
 typealias ConsumerMetadata = Map<String, String>
-typealias ProducerMetadata = Map<String, String>
+typealias ProducerMetadata = Pair<Map<String, String>, Set<Element>>

--- a/crumb-compiler/build.gradle
+++ b/crumb-compiler/build.gradle
@@ -31,8 +31,8 @@ dependencies {
   kapt deps.apt.moshiKotlinCodegen
   kapt deps.apt.incapProcessor
   compileOnly deps.apt.autoServiceAnnotations
-  compileOnly deps.apt.incap
 
+  api deps.apt.incap
   api deps.misc.moshi
   api project(":crumb-core")
   api project(':crumb-compiler-api')

--- a/crumb-compiler/build.gradle
+++ b/crumb-compiler/build.gradle
@@ -29,7 +29,9 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
 dependencies {
   kapt deps.apt.autoService
   kapt deps.apt.moshiKotlinCodegen
+  kapt deps.apt.incapProcessor
   compileOnly deps.apt.autoServiceAnnotations
+  compileOnly deps.apt.incap
 
   api deps.misc.moshi
   api project(":crumb-core")

--- a/crumb-compiler/src/main/kotlin/com/uber/crumb/CrumbProcessor.kt
+++ b/crumb-compiler/src/main/kotlin/com/uber/crumb/CrumbProcessor.kt
@@ -235,7 +235,7 @@ class CrumbProcessor : AbstractProcessor {
           val adapterName = producer.classNameOf()
           val packageName = producer.packageName()
           // Write metadata to resources for consumers to pick up
-          val crumbModel = CrumbModel("$packageName.$adapterName", globalExtras)
+          val crumbModel = CrumbModel("$packageName.$adapterName", globalExtras.mapValues { it.value.first })
           val buffer = Buffer().also {
             it.use {
               crumbAdapter.toJson(it, crumbModel)
@@ -246,7 +246,7 @@ class CrumbProcessor : AbstractProcessor {
               fileName = "$adapterName$CRUMB_INDEX_SUFFIX",
               dataToWrite = buffer,
               outputLanguage = CrumbOutputLanguage.languageForType(producer),
-              originatingElements = setOf(producer)
+              originatingElements = setOf(producer) + globalExtras.values.flatMap { it.second }
           )
         }
   }

--- a/crumb-compiler/src/main/kotlin/com/uber/crumb/CrumbProcessor.kt
+++ b/crumb-compiler/src/main/kotlin/com/uber/crumb/CrumbProcessor.kt
@@ -20,7 +20,6 @@ import com.google.auto.service.AutoService
 import com.google.common.annotations.VisibleForTesting
 import com.squareup.moshi.JsonClass
 import com.squareup.moshi.Moshi
-import com.uber.crumb.CrumbProcessor.Companion.OPTION_VERBOSE
 import com.uber.crumb.annotations.CrumbConsumable
 import com.uber.crumb.annotations.CrumbConsumer
 import com.uber.crumb.annotations.CrumbProducer
@@ -29,6 +28,9 @@ import com.uber.crumb.compiler.api.ConsumerMetadata
 import com.uber.crumb.compiler.api.CrumbConsumerExtension
 import com.uber.crumb.compiler.api.CrumbContext
 import com.uber.crumb.compiler.api.CrumbExtension
+import com.uber.crumb.compiler.api.CrumbExtension.IncrementalExtensionType.AGGREGATING
+import com.uber.crumb.compiler.api.CrumbExtension.IncrementalExtensionType.ISOLATING
+import com.uber.crumb.compiler.api.CrumbExtension.IncrementalExtensionType.UNKNOWN
 import com.uber.crumb.compiler.api.CrumbProducerExtension
 import com.uber.crumb.compiler.api.ExtensionKey
 import com.uber.crumb.compiler.api.ProducerMetadata
@@ -37,13 +39,15 @@ import com.uber.crumb.core.CrumbLog.Client.MessagerClient
 import com.uber.crumb.core.CrumbManager
 import com.uber.crumb.core.CrumbOutputLanguage
 import okio.Buffer
+import net.ltgt.gradle.incap.IncrementalAnnotationProcessor
+import net.ltgt.gradle.incap.IncrementalAnnotationProcessorType
+import net.ltgt.gradle.incap.IncrementalAnnotationProcessorType.DYNAMIC
 import java.util.ServiceConfigurationError
 import java.util.ServiceLoader
 import javax.annotation.processing.AbstractProcessor
 import javax.annotation.processing.ProcessingEnvironment
 import javax.annotation.processing.Processor
 import javax.annotation.processing.RoundEnvironment
-import javax.annotation.processing.SupportedOptions
 import javax.lang.model.SourceVersion
 import javax.lang.model.element.Element
 import javax.lang.model.element.TypeElement
@@ -57,7 +61,7 @@ import javax.tools.Diagnostic.Kind.WARNING
  * Processes all [CrumbConsumer] and [CrumbProducer] annotated types.
  */
 @AutoService(Processor::class)
-@SupportedOptions(OPTION_VERBOSE)
+@IncrementalAnnotationProcessor(DYNAMIC)
 class CrumbProcessor : AbstractProcessor {
 
   companion object {
@@ -113,6 +117,27 @@ class CrumbProcessor : AbstractProcessor {
 
   override fun getSupportedSourceVersion(): SourceVersion {
     return SourceVersion.latestSupported()
+  }
+
+  override fun getSupportedOptions(): Set<String> {
+    val producerIncrementalType = producerExtensions.asSequence()
+        .map { it.producerIncrementalType(processingEnv) }
+        .min()
+        ?: ISOLATING
+    val consumerIncrementalType = consumerExtensions.asSequence()
+        .map { it.consumerIncrementalType(processingEnv) }
+        .min()
+        ?: ISOLATING
+    return arrayOf(OPTION_VERBOSE, producerIncrementalType.toOption(), consumerIncrementalType.toOption())
+        .filterNotNullTo(mutableSetOf())
+  }
+
+  private fun CrumbExtension.IncrementalExtensionType.toOption(): String? {
+    return when (this) {
+      ISOLATING -> IncrementalAnnotationProcessorType.ISOLATING.processorOption
+      AGGREGATING -> IncrementalAnnotationProcessorType.AGGREGATING.processorOption
+      UNKNOWN -> null
+    }
   }
 
   @Synchronized

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -21,6 +21,7 @@ def versions = [
     errorProne: '2.3.3',
     dokka: '0.9.18',
     errorPronePlugin: '0.7.1',
+    incap: '0.2',
     gjf: '1.7',
     kotlin: '1.3.41',
     ktlint: '0.34.2',
@@ -40,6 +41,8 @@ ext.deps = [
         autoValueGson: "com.ryanharter.auto.value:auto-value-gson:${versions.autoValueGson}",
         autoValueGsonRuntime: "com.ryanharter.auto.value:auto-value-gson-runtime:${versions.autoValueGson}",
         autoValueMoshi: "com.ryanharter.auto.value:auto-value-moshi:0.4.7",
+        incap: "net.ltgt.gradle.incap:incap:${versions.incap}",
+        incapProcessor: "net.ltgt.gradle.incap:incap-processor:${versions.incap}",
         moshiKotlinCodegen: "com.squareup.moshi:moshi-kotlin-codegen:${versions.moshi}",
     ],
 

--- a/sample/experiments-compiler/experiment-enums-compiler/java/src/main/java/com/uber/crumb/sample/experimentenumscompiler/ExperimentsCompiler.java
+++ b/sample/experiments-compiler/experiment-enums-compiler/java/src/main/java/com/uber/crumb/sample/experimentenumscompiler/ExperimentsCompiler.java
@@ -189,7 +189,8 @@ public final class ExperimentsCompiler implements CrumbProducerExtension, CrumbC
               type);
       return new Pair<>(ImmutableMap.of(), ImmutableSet.of());
     }
-    return new Pair<>(ImmutableMap.of(METADATA_KEY, type.getQualifiedName().toString()), ImmutableSet.of(type));
+    return new Pair<>(ImmutableMap.of(METADATA_KEY, type.getQualifiedName().toString()),
+        ImmutableSet.of(type));
   }
 
   @Override public IncrementalExtensionType producerIncrementalType(

--- a/sample/plugins-compiler/plugins-compiler/java/src/main/java/com/uber/crumb/sample/pluginscompiler/PluginsCompiler.java
+++ b/sample/plugins-compiler/plugins-compiler/java/src/main/java/com/uber/crumb/sample/pluginscompiler/PluginsCompiler.java
@@ -225,7 +225,8 @@ public final class PluginsCompiler implements CrumbProducerExtension, CrumbConsu
       return new Pair<>(ImmutableMap.of(), ImmutableSet.of());
     }
 
-    return new Pair<>(ImmutableMap.of(METADATA_KEY, type.getQualifiedName().toString()), ImmutableSet.of(type));
+    return new Pair<>(ImmutableMap.of(METADATA_KEY, type.getQualifiedName().toString()),
+        ImmutableSet.of(type));
   }
 
   @Override public IncrementalExtensionType producerIncrementalType(


### PR DESCRIPTION
Resolves #33 

This borrows heavily from AutoValue's API for supporting incremental apt with extensions, and allowing extensions to declare their kind of apt.

Producers have to report their originating elements for the CrumbIndex types, consumers don't have to. Consumers should usually be isolating, producers should usually be aggregating.