### PR TITLE
Switch to proto binary format

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,8 +18,8 @@ buildscript {
   apply from: 'gradle/dependencies.gradle'
   repositories {
     mavenCentral()
-    jcenter()
     google()
+    jcenter()
   }
   dependencies {
     classpath deps.build.gradlePlugins.android
@@ -34,14 +34,16 @@ plugins {
 allprojects {
   buildscript {
     repositories {
-      jcenter()
+      mavenCentral()
       google()
+      jcenter()
     }
   }
 
   repositories {
-    jcenter()
+    mavenCentral()
     google()
+    jcenter()
   }
 }
 

--- a/crumb-annotations/src/main/java/com/uber/crumb/annotations/internal/CrumbIndex.java
+++ b/crumb-annotations/src/main/java/com/uber/crumb/annotations/internal/CrumbIndex.java
@@ -28,6 +28,5 @@ import static java.lang.annotation.ElementType.TYPE;
 @Retention(RetentionPolicy.CLASS)
 @Target(TYPE)
 public @interface CrumbIndex {
-  // TODO(zsweers) Maybe use a bytearray? Mirroring Kotlin's metadata annotations & they use String
-  String value();
+  byte[] value();
 }

--- a/crumb-compiler/build.gradle
+++ b/crumb-compiler/build.gradle
@@ -43,7 +43,6 @@ wire {
 
 dependencies {
   kapt deps.apt.autoService
-  kapt deps.apt.moshiKotlinCodegen
   kapt deps.apt.incapProcessor
   compileOnly deps.apt.autoServiceAnnotations
 

--- a/crumb-compiler/build.gradle
+++ b/crumb-compiler/build.gradle
@@ -17,12 +17,27 @@ plugins {
   id 'org.jetbrains.kotlin.jvm'
   id 'org.jetbrains.kotlin.kapt'
   id 'org.jetbrains.dokka'
+  id 'com.squareup.wire'
 }
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
   kotlinOptions {
     jvmTarget = "1.8"
     freeCompilerArgs = ['-Xjsr305=strict']
+  }
+}
+
+sourceSets {
+  main {
+    java {
+      srcDir "${project.buildDir}/generated/src/main/java"
+    }
+  }
+}
+
+wire {
+  kotlin {
+    javaInterop = false
   }
 }
 
@@ -34,8 +49,11 @@ dependencies {
 
   api deps.apt.incap
   api deps.misc.moshi
+  compileOnly deps.apt.autoServiceAnnotations
+
   api project(":crumb-core")
   api project(':crumb-compiler-api')
+  implementation 'com.squareup.wire:wire-runtime:3.0.0-rc01'
 
   implementation deps.apt.autoCommon
   implementation deps.kotlin.stdLibJdk8

--- a/crumb-compiler/build.gradle
+++ b/crumb-compiler/build.gradle
@@ -52,7 +52,7 @@ dependencies {
 
   api project(":crumb-core")
   api project(':crumb-compiler-api')
-  implementation 'com.squareup.wire:wire-runtime:3.0.0-rc01'
+  implementation deps.misc.wire
 
   implementation deps.apt.autoCommon
   implementation deps.kotlin.stdLibJdk8

--- a/crumb-compiler/src/main/kotlin/com/uber/crumb/CrumbProcessor.kt
+++ b/crumb-compiler/src/main/kotlin/com/uber/crumb/CrumbProcessor.kt
@@ -18,7 +18,6 @@ package com.uber.crumb
 
 import com.google.auto.service.AutoService
 import com.google.common.annotations.VisibleForTesting
-import com.uber.crumb.CrumbProcessor.Companion.OPTION_VERBOSE
 import com.uber.crumb.annotations.CrumbConsumable
 import com.uber.crumb.annotations.CrumbConsumer
 import com.uber.crumb.annotations.CrumbProducer
@@ -38,10 +37,10 @@ import com.uber.crumb.core.CrumbManager
 import com.uber.crumb.core.CrumbOutputLanguage
 import com.uber.crumb.internal.CrumbModel
 import com.uber.crumb.internal.CrumbModelExtra
-import okio.Buffer
 import net.ltgt.gradle.incap.IncrementalAnnotationProcessor
 import net.ltgt.gradle.incap.IncrementalAnnotationProcessorType
 import net.ltgt.gradle.incap.IncrementalAnnotationProcessorType.DYNAMIC
+import okio.Buffer
 import okio.GzipSink
 import okio.GzipSource
 import okio.buffer
@@ -234,7 +233,7 @@ class CrumbProcessor : AbstractProcessor {
           val adapterName = producer.classNameOf()
           val packageName = producer.packageName()
           // Write metadata to resources for consumers to pick up
-          val crumbModel = CrumbModel("$packageName.$adapterName", globalExtras.map { (extensionKey, producerMetadata) -> CrumbModelExtra(extensionKey, producerMetadata) })
+          val crumbModel = CrumbModel("$packageName.$adapterName", globalExtras.map { (extensionKey, producerMetadata) -> CrumbModelExtra(extensionKey, producerMetadata.first) })
           val buffer = Buffer()
           GzipSink(buffer).buffer().also {
             it.use {

--- a/crumb-compiler/src/main/kotlin/com/uber/crumb/CrumbProcessor.kt
+++ b/crumb-compiler/src/main/kotlin/com/uber/crumb/CrumbProcessor.kt
@@ -18,13 +18,11 @@ package com.uber.crumb
 
 import com.google.auto.service.AutoService
 import com.google.common.annotations.VisibleForTesting
-import com.squareup.moshi.JsonClass
-import com.squareup.moshi.Moshi
+import com.uber.crumb.CrumbProcessor.Companion.OPTION_VERBOSE
 import com.uber.crumb.annotations.CrumbConsumable
 import com.uber.crumb.annotations.CrumbConsumer
 import com.uber.crumb.annotations.CrumbProducer
 import com.uber.crumb.annotations.CrumbQualifier
-import com.uber.crumb.compiler.api.ConsumerMetadata
 import com.uber.crumb.compiler.api.CrumbConsumerExtension
 import com.uber.crumb.compiler.api.CrumbContext
 import com.uber.crumb.compiler.api.CrumbExtension
@@ -38,10 +36,15 @@ import com.uber.crumb.core.CrumbLog
 import com.uber.crumb.core.CrumbLog.Client.MessagerClient
 import com.uber.crumb.core.CrumbManager
 import com.uber.crumb.core.CrumbOutputLanguage
+import com.uber.crumb.internal.CrumbModel
+import com.uber.crumb.internal.CrumbModelExtra
 import okio.Buffer
 import net.ltgt.gradle.incap.IncrementalAnnotationProcessor
 import net.ltgt.gradle.incap.IncrementalAnnotationProcessorType
 import net.ltgt.gradle.incap.IncrementalAnnotationProcessorType.DYNAMIC
+import okio.GzipSink
+import okio.GzipSource
+import okio.buffer
 import java.util.ServiceConfigurationError
 import java.util.ServiceLoader
 import javax.annotation.processing.AbstractProcessor
@@ -75,10 +78,6 @@ class CrumbProcessor : AbstractProcessor {
 
     private const val CRUMB_INDICES_PACKAGE = "com.uber.crumb.indices"
   }
-
-  private val crumbAdapter = Moshi.Builder()
-      .build()
-      .adapter(CrumbModel::class.java)
 
   // Depending on how this CrumbProcessor was constructed, we might already have a list of
   // extensions when init() is run, or, if `extensions` is null, we have a ClassLoader that will be
@@ -235,10 +234,11 @@ class CrumbProcessor : AbstractProcessor {
           val adapterName = producer.classNameOf()
           val packageName = producer.packageName()
           // Write metadata to resources for consumers to pick up
-          val crumbModel = CrumbModel("$packageName.$adapterName", globalExtras.mapValues { it.value.first })
-          val buffer = Buffer().also {
+          val crumbModel = CrumbModel("$packageName.$adapterName", globalExtras.map { (extensionKey, producerMetadata) -> CrumbModelExtra(extensionKey, producerMetadata) })
+          val buffer = Buffer()
+          GzipSink(buffer).buffer().also {
             it.use {
-              crumbAdapter.toJson(it, crumbModel)
+              CrumbModel.ADAPTER.encode(it, crumbModel)
             }
           }
           crumbManager.store(
@@ -282,11 +282,14 @@ class CrumbProcessor : AbstractProcessor {
       return
     }
 
-    val producerMetadata = producerMetadataBlobs.map { it.use { crumbAdapter.fromJson(it)!! } }
+    val producerMetadata = producerMetadataBlobs.map { blob ->
+      GzipSource(blob).buffer().use {
+        CrumbModel.ADAPTER.decode(it)
+      }
+    }
     val metadataByExtension = producerMetadata
-        .map { it.extras }
-        .flatMap { it.entries }
-        .groupBy({ it.key }) { it.value }
+        .flatMap { it.extras }
+        .groupBy({ it.extensionKey }) { it.producerMetadata }
         .mapValues { it.value.toSet() }
 
     // Iterate through the consumers to generate their implementations.
@@ -321,8 +324,3 @@ class CrumbProcessor : AbstractProcessor {
 
 @Suppress("UNCHECKED_CAST", "NOTHING_TO_INLINE")
 private inline fun <T> Iterable<*>.cast() = map { it as T }
-
-@JsonClass(generateAdapter = true)
-internal data class CrumbModel(
-    val name: String,
-    val extras: Map<ExtensionKey, ConsumerMetadata>)

--- a/crumb-compiler/src/main/proto/com/uber/crumb/internal/crumb_model.proto
+++ b/crumb-compiler/src/main/proto/com/uber/crumb/internal/crumb_model.proto
@@ -1,0 +1,22 @@
+syntax = "proto2";
+
+package com.uber.crumb;
+
+option java_package = "com.uber.crumb.internal";
+
+message CrumbModel {
+  // The name of the specific data model, usually defined by
+  required string name = 1;
+
+  // We use
+  repeated CrumbModelExtra extras = 2;
+}
+
+// Defined because we can't have nested maps
+message CrumbModelExtra {
+  //
+  required string extensionKey = 1;
+
+  //
+  map<string, string> producerMetadata = 2;
+}

--- a/crumb-core/src/main/kotlin/com/uber/crumb/core/CrumbManager.kt
+++ b/crumb-core/src/main/kotlin/com/uber/crumb/core/CrumbManager.kt
@@ -18,7 +18,6 @@ package com.uber.crumb.core
 import com.uber.crumb.annotations.internal.CrumbIndex
 import okio.Buffer
 import okio.BufferedSource
-import okio.ByteString.Companion.encodeUtf8
 import javax.annotation.processing.ProcessingEnvironment
 import javax.lang.model.element.Element
 import javax.lang.model.element.PackageElement
@@ -53,7 +52,7 @@ class CrumbManager(private val env: ProcessingEnvironment,
 
     return crumbGenPackage.enclosedElements.mapNotNullTo(mutableSetOf()) { element ->
       element.getAnnotation(CrumbIndex::class.java)?.run {
-        Buffer().apply { write(value.encodeUtf8()) }
+        Buffer().apply { write(value) }
       }
     }
   }

--- a/crumb-core/src/main/kotlin/com/uber/crumb/core/CrumbOutputLanguage.kt
+++ b/crumb-core/src/main/kotlin/com/uber/crumb/core/CrumbOutputLanguage.kt
@@ -49,7 +49,7 @@ enum class CrumbOutputLanguage {
       val typeSpec = TypeSpec.classBuilder(fileName)
           .addJavadoc(EXPLANATORY_COMMENT)
           .addAnnotation(AnnotationSpec.builder(CrumbIndex::class.java)
-              .addMember("value", "\$S", dataToWrite.readUtf8())
+              .addMember("value", "\$L", dataToWrite.readByteArray().joinToString(",", prefix = "{", postfix = "}"))
               .build())
           .addModifiers(FINAL)
           .addMethod(MethodSpec.constructorBuilder().addModifiers(PRIVATE).build())
@@ -75,7 +75,7 @@ enum class CrumbOutputLanguage {
       val typeSpec = KotlinTypeSpec.objectBuilder(fileName)
           .addKdoc(EXPLANATORY_COMMENT)
           .addAnnotation(KotlinAnnotationSpec.builder(CrumbIndex::class)
-              .addMember("%S", dataToWrite.readUtf8())
+              .addMember("%L", dataToWrite.readByteArray().joinToString(",", prefix = "[", postfix = "]"))
               .build())
           .addModifiers(KModifier.PRIVATE)
           .apply {

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -42,8 +42,7 @@ ext.deps = [
         autoValueGsonRuntime: "com.ryanharter.auto.value:auto-value-gson-runtime:${versions.autoValueGson}",
         autoValueMoshi: "com.ryanharter.auto.value:auto-value-moshi:0.4.7",
         incap: "net.ltgt.gradle.incap:incap:${versions.incap}",
-        incapProcessor: "net.ltgt.gradle.incap:incap-processor:${versions.incap}",
-        moshiKotlinCodegen: "com.squareup.moshi:moshi-kotlin-codegen:${versions.moshi}",
+        incapProcessor: "net.ltgt.gradle.incap:incap-processor:${versions.incap}"
     ],
 
     build: [

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -26,7 +26,8 @@ def versions = [
     kotlin: '1.3.41',
     ktlint: '0.34.2',
     moshi: '1.8.0',
-    spotless: '3.24.0'
+    spotless: '3.24.0',
+    wire: "3.0.0-rc01"
 ]
 
 ext.deps = [
@@ -70,14 +71,15 @@ ext.deps = [
     misc: [
         appCompat: 'androidx.appcompat:appcompat:1.0.2',
         errorProneAnnotations: "com.google.errorprone:error_prone_annotations:${versions.errorProne}",
+        gson: "com.google.code.gson:gson:2.8.5",
+        guava: "com.google.guava:guava:28.0-jre",
         javapoet: "com.squareup:javapoet:1.11.1",
         javaxExtras: 'com.uber.javaxextras:javax-extras:0.1.0',
         kotlinMetadata: 'me.eugeniomarletti.kotlin.metadata:kotlin-metadata:1.4.0',
         kotlinpoet: 'com.squareup:kotlinpoet:1.3.0',
-        gson: "com.google.code.gson:gson:2.8.5",
-        guava: "com.google.guava:guava:28.0-jre",
         moshi: "com.squareup.moshi:moshi:${versions.moshi}",
         okio: "com.squareup.okio:okio:2.2.0",
+        wire: "com.squareup.wire:wire-runtime:3.0.0-rc01"
     ],
 
     rx: [

--- a/sample/experiments-compiler/android/kotlin/app/build.gradle
+++ b/sample/experiments-compiler/android/kotlin/app/build.gradle
@@ -44,9 +44,18 @@ repositories {
   google()
 }
 
+// https://youtrack.jetbrains.com/issue/KT-31641
+// https://youtrack.jetbrains.com/issue/KT-33206
+configurations {
+  kapt.extendsFrom(mppFriendlyKapt)
+}
+configurations.getByName("mppFriendlyKapt") {
+  attributes.attribute(Usage.USAGE_ATTRIBUTE, getObjects().named(Usage, Usage.JAVA_RUNTIME))
+}
+
 dependencies {
-  kapt project(":crumb-compiler")
-  kapt project(":sample:experiments-compiler:experiment-enums-compiler:kotlin")
+  mppFriendlyKapt project(":crumb-compiler")
+  mppFriendlyKapt project(":sample:experiments-compiler:experiment-enums-compiler:kotlin")
   implementation project(":sample:experiments-compiler:experiment-enums-compiler:annotations")
   implementation project(":crumb-annotations")
   implementation project(":sample:experiments-compiler:android:kotlin:library")

--- a/sample/experiments-compiler/android/kotlin/library/build.gradle
+++ b/sample/experiments-compiler/android/kotlin/library/build.gradle
@@ -36,9 +36,20 @@ android {
   }
 }
 
+
+
+// https://youtrack.jetbrains.com/issue/KT-31641
+// https://youtrack.jetbrains.com/issue/KT-33206
+configurations {
+  kapt.extendsFrom(mppFriendlyKapt)
+}
+configurations.getByName("mppFriendlyKapt") {
+  attributes.attribute(Usage.USAGE_ATTRIBUTE, getObjects().named(Usage, Usage.JAVA_RUNTIME))
+}
+
 dependencies {
-  kapt project(":crumb-compiler")
-  kapt project(":sample:experiments-compiler:experiment-enums-compiler:kotlin")
+  mppFriendlyKapt project(":crumb-compiler")
+  mppFriendlyKapt project(":sample:experiments-compiler:experiment-enums-compiler:kotlin")
   implementation project(":crumb-annotations")
   implementation project(":sample:experiments-compiler:experiment-enums-compiler:annotations")
 }

--- a/sample/experiments-compiler/jvm/kotlin/app/build.gradle
+++ b/sample/experiments-compiler/jvm/kotlin/app/build.gradle
@@ -27,9 +27,18 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
   }
 }
 
+// https://youtrack.jetbrains.com/issue/KT-31641
+// https://youtrack.jetbrains.com/issue/KT-33206
+configurations {
+  kapt.extendsFrom(mppFriendlyKapt)
+}
+configurations.getByName("mppFriendlyKapt") {
+  attributes.attribute(Usage.USAGE_ATTRIBUTE, getObjects().named(Usage, Usage.JAVA_RUNTIME))
+}
+
 dependencies {
-  kapt project(":crumb-compiler")
-  kapt project(":sample:experiments-compiler:experiment-enums-compiler:kotlin")
+  mppFriendlyKapt project(":crumb-compiler")
+  mppFriendlyKapt project(":sample:experiments-compiler:experiment-enums-compiler:kotlin")
   implementation project(":crumb-annotations")
   implementation project(":sample:experiments-compiler:jvm:kotlin:library")
   implementation deps.kotlin.stdLib

--- a/sample/experiments-compiler/jvm/kotlin/library/build.gradle
+++ b/sample/experiments-compiler/jvm/kotlin/library/build.gradle
@@ -27,9 +27,18 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
   }
 }
 
+// https://youtrack.jetbrains.com/issue/KT-31641
+// https://youtrack.jetbrains.com/issue/KT-33206
+configurations {
+  kapt.extendsFrom(mppFriendlyKapt)
+}
+configurations.getByName("mppFriendlyKapt") {
+  attributes.attribute(Usage.USAGE_ATTRIBUTE, getObjects().named(Usage, Usage.JAVA_RUNTIME))
+}
+
 dependencies {
-  kapt project(":crumb-compiler")
-  kapt project(":sample:experiments-compiler:experiment-enums-compiler:kotlin")
+  mppFriendlyKapt project(":crumb-compiler")
+  mppFriendlyKapt project(":sample:experiments-compiler:experiment-enums-compiler:kotlin")
   api project(":crumb-annotations")
   api project(":sample:experiments-compiler:experiment-enums-compiler:annotations")
 }

--- a/sample/plugins-compiler/android/kotlin/app/build.gradle
+++ b/sample/plugins-compiler/android/kotlin/app/build.gradle
@@ -44,9 +44,18 @@ repositories {
   google()
 }
 
+// https://youtrack.jetbrains.com/issue/KT-31641
+// https://youtrack.jetbrains.com/issue/KT-33206
+configurations {
+  kapt.extendsFrom(mppFriendlyKapt)
+}
+configurations.getByName("mppFriendlyKapt") {
+  attributes.attribute(Usage.USAGE_ATTRIBUTE, getObjects().named(Usage, Usage.JAVA_RUNTIME))
+}
+
 dependencies {
-  kapt project(":crumb-compiler")
-  kapt project(":sample:plugins-compiler:plugins-compiler:kotlin")
+  mppFriendlyKapt project(":crumb-compiler")
+  mppFriendlyKapt project(":sample:plugins-compiler:plugins-compiler:kotlin")
   implementation project(":sample:plugins-compiler:plugins-compiler:annotations")
   implementation project(":crumb-annotations")
   implementation project(":sample:plugins-compiler:android:kotlin:library")

--- a/sample/plugins-compiler/android/kotlin/library/build.gradle
+++ b/sample/plugins-compiler/android/kotlin/library/build.gradle
@@ -36,9 +36,18 @@ android {
   }
 }
 
+// https://youtrack.jetbrains.com/issue/KT-31641
+// https://youtrack.jetbrains.com/issue/KT-33206
+configurations {
+  kapt.extendsFrom(mppFriendlyKapt)
+}
+configurations.getByName("mppFriendlyKapt") {
+  attributes.attribute(Usage.USAGE_ATTRIBUTE, getObjects().named(Usage, Usage.JAVA_RUNTIME))
+}
+
 dependencies {
-  kapt project(":crumb-compiler")
-  kapt project(":sample:plugins-compiler:plugins-compiler:kotlin")
+  mppFriendlyKapt project(":crumb-compiler")
+  mppFriendlyKapt project(":sample:plugins-compiler:plugins-compiler:kotlin")
   implementation deps.kotlin.stdLib
   implementation project(":crumb-annotations")
   implementation project(":sample:plugins-compiler:plugins-compiler:annotations")

--- a/sample/plugins-compiler/jvm/kotlin/app/build.gradle
+++ b/sample/plugins-compiler/jvm/kotlin/app/build.gradle
@@ -27,9 +27,18 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
   }
 }
 
+// https://youtrack.jetbrains.com/issue/KT-31641
+// https://youtrack.jetbrains.com/issue/KT-33206
+configurations {
+  kapt.extendsFrom(mppFriendlyKapt)
+}
+configurations.getByName("mppFriendlyKapt") {
+  attributes.attribute(Usage.USAGE_ATTRIBUTE, getObjects().named(Usage, Usage.JAVA_RUNTIME))
+}
+
 dependencies {
-  kapt project(":crumb-compiler")
-  kapt project(":sample:plugins-compiler:plugins-compiler:kotlin")
+  mppFriendlyKapt project(":crumb-compiler")
+  mppFriendlyKapt project(":sample:plugins-compiler:plugins-compiler:kotlin")
   implementation project(":crumb-annotations")
   implementation project(":sample:plugins-compiler:jvm:kotlin:library")
   implementation project(":sample:plugins-compiler:translations-api")

--- a/sample/plugins-compiler/jvm/kotlin/library/build.gradle
+++ b/sample/plugins-compiler/jvm/kotlin/library/build.gradle
@@ -27,9 +27,18 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
   }
 }
 
+// https://youtrack.jetbrains.com/issue/KT-31641
+// https://youtrack.jetbrains.com/issue/KT-33206
+configurations {
+  kapt.extendsFrom(mppFriendlyKapt)
+}
+configurations.getByName("mppFriendlyKapt") {
+  attributes.attribute(Usage.USAGE_ATTRIBUTE, getObjects().named(Usage, Usage.JAVA_RUNTIME))
+}
+
 dependencies {
-  kapt project(":crumb-compiler")
-  kapt project(":sample:plugins-compiler:plugins-compiler:kotlin")
+  mppFriendlyKapt project(":crumb-compiler")
+  mppFriendlyKapt project(":sample:plugins-compiler:plugins-compiler:kotlin")
   implementation deps.kotlin.stdLib
   api project(":crumb-annotations")
   api project(":sample:plugins-compiler:plugins-compiler:annotations")

--- a/settings.gradle
+++ b/settings.gradle
@@ -46,7 +46,7 @@ pluginManagement {
           useVersion("0.21")
           break
         case 'com.squareup.wire':
-          useModule('com.squareup.wire:wire-gradle-plugin:3.0.0-rc01')
+          useModule("com.squareup.wire:wire-gradle-plugin:${deps.versions.wire}")
           break
         case 'com.diffplug.gradle.spotless':
           useVersion(deps.versions.spotless)

--- a/settings.gradle
+++ b/settings.gradle
@@ -45,6 +45,9 @@ pluginManagement {
         case 'net.ltgt.apt-idea':
           useVersion("0.21")
           break
+        case 'com.squareup.wire':
+          useModule('com.squareup.wire:wire-gradle-plugin:3.0.0-rc01')
+          break
         case 'com.diffplug.gradle.spotless':
           useVersion(deps.versions.spotless)
           break
@@ -54,6 +57,7 @@ pluginManagement {
   repositories {
     jcenter()
     google()
+    mavenCentral()
     gradlePluginPortal()
   }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -55,10 +55,10 @@ pluginManagement {
     }
   }
   repositories {
-    jcenter()
-    google()
     mavenCentral()
+    google()
     gradlePluginPortal()
+    jcenter()
   }
 }
 


### PR DESCRIPTION
This adopts a protobuf-based binary format using Wire + gzip, resolves #40 

Before: 641 bytes + encoding

```java
// Generated, do not modify!
package com.uber.crumb.indices;

import com.uber.crumb.annotations.internal.CrumbIndex;

/**
 * This type + annotation exists for sharing information to the Crumb annotation processor and should not be considered public API. */
@CrumbIndex("{\"name\":\"com.uber.crumb.integration.lib1.Lib1Producer\",\"extras\":{\"com.uber.crumb.integration.compiler.GsonSupport\":{\"crumb.extensions.gson\":\"{\\\"com.uber.crumb.integration.lib1.Lib1Enum\\\":{\\\"methodName\\\":\\\"typeAdapter\\\",\\\"argCount\\\":0},\\\"com.uber.crumb.integration.lib1.Lib1Model\\\":{\\\"methodName\\\":\\\"typeAdapter\\\",\\\"argCount\\\":1}}\"},\"com.uber.crumb.integration.compiler.MoshiSupport\":{\"crumb.extensions.moshi\":\"{\\\"com.uber.crumb.integration.lib1.Lib1Enum\\\":{\\\"methodName\\\":\\\"jsonAdapter\\\",\\\"argCount\\\":0,\\\"isFactory\\\":true},\\\"com.uber.crumb.integration.lib1.Lib1Model\\\":{\\\"methodName\\\":\\\"jsonAdapter\\\",\\\"argCount\\\":1,\\\"isFactory\\\":false}}\"}}}")
final class Lib1ProducerCrumbIndex {
  private Lib1ProducerCrumbIndex() {
  }
}
```

After: 241 bytes + no encoding

```java
// Generated, do not modify!
package com.uber.crumb.indices;

import com.uber.crumb.annotations.internal.CrumbIndex;

/**
 * This type + annotation exists for sharing information to the Crumb annotation processor and should not be considered public API. */
@CrumbIndex({31,-117,8,0,0,0,0,0,0,0,-91,-112,61,78,-60,48,16,-123,21,74,-105,-106,-32,0,83,71,102,-45,-90,67,8,104,88,-124,-60,9,-100,100,-56,122,21,123,-84,-15,88,98,-75,-54,89,-72,0,-25,-96,-27,30,28,-127,10,35,68,-127,-8,81,-92,109,-90,121,111,-34,-45,-9,84,-35,-109,55,-71,67,54,61,103,-33,25,23,4,71,-74,-30,40,-104,-55,117,-115,-71,46,-25,-106,105,-56,61,-78,126,-85,-44,-23,63,15,69,-118,110,42,-46,85,-94,112,-105,99,36,22,-3,92,-87,-29,79,43,62,8,-122,84,-116,-55,-116,-59,-96,-97,-86,61,44,-87,-65,8,-39,67,-69,7,-113,-78,-95,-31,-58,122,-124,22,100,23,-15,108,-80,81,-112,-95,6,-53,-29,57,-27,32,-48,-82,-26,122,81,-24,-102,6,-100,22,-89,54,-13,-84,31,-113,-44,106,9,-4,-102,-46,-58,125,-47,-65,86,-22,-28,7,-67,-1,112,-24,-105,67,-16,-73,101,-64,95,-15,107,112,-23,-46,-10,66,-68,-125,86,56,-29,65,123,-4,85,-45,124,-85,-71,-73,83,-62,121,126,7,-92,-101,14,-97,77,2,0,0})
final class Lib1ProducerCrumbIndex {
  private Lib1ProducerCrumbIndex() {
  }
}
```