### PR TITLE
 Support local producer-generated models in consumers 

### DIFF
--- a/integration-test/compiler/src/main/kotlin/com/uber/crumb/integration/compiler/GsonSupport.kt
+++ b/integration-test/compiler/src/main/kotlin/com/uber/crumb/integration/compiler/GsonSupport.kt
@@ -52,6 +52,7 @@ import com.uber.crumb.compiler.api.ProducerMetadata
 import com.uber.crumb.integration.annotations.GsonFactory
 import com.uber.crumb.integration.annotations.GsonFactory.Type.CONSUMER
 import com.uber.crumb.integration.annotations.GsonFactory.Type.PRODUCER
+import javax.annotation.Nullable
 import javax.annotation.processing.ProcessingEnvironment
 import javax.lang.model.element.AnnotationMirror
 import javax.lang.model.element.Element
@@ -200,6 +201,7 @@ class GsonSupport : CrumbConsumerExtension, CrumbProducerExtension {
     val create = MethodSpec.methodBuilder("create")
         .addModifiers(PUBLIC)
         .addTypeVariable(t)
+        .addAnnotation(Nullable::class.java)
         .addAnnotation(Override::class.java)
         .addAnnotation(AnnotationSpec.builder(SuppressWarnings::class.java)
             .addMember("value", "\"unchecked\"")
@@ -307,6 +309,9 @@ class GsonSupport : CrumbConsumerExtension, CrumbProducerExtension {
 
     // A utility createTypeAdapter method for methods to use and not worry about reflection stuff
     val typeAdapterCreator = MethodSpec.methodBuilder("createTypeAdapter")
+        .addAnnotation(AnnotationSpec.builder(SuppressWarnings::class.java)
+            .addMember("value", "\$S", "unchecked")
+            .build())
         .addModifiers(PRIVATE, STATIC)
         .addTypeVariable(t)
         .returns(result)
@@ -358,6 +363,7 @@ class GsonSupport : CrumbConsumerExtension, CrumbProducerExtension {
     val create = MethodSpec.methodBuilder("create")
         .addModifiers(PUBLIC)
         .addTypeVariable(t)
+        .addAnnotation(Nullable::class.java)
         .addAnnotation(Override::class.java)
         .addParameters(ImmutableSet.of(gson, typeParam))
         .returns(result)
@@ -383,10 +389,11 @@ class GsonSupport : CrumbConsumerExtension, CrumbProducerExtension {
 
     // Begin the switch
     create.beginControlFlow("switch (packageName)")
-    modelsByPackage.forEach { packageName, entries ->
+    modelsByPackage.forEach { (packageName, entries) ->
       // Create the package-specific method
       val packageCreatorMethod = MethodSpec.methodBuilder(
           nameAllocator.newName("${packageName}TypeAdapter"))
+          .addAnnotation(Nullable::class.java)
           .addModifiers(PRIVATE, STATIC)
           .addTypeVariable(t)
           .returns(result)

--- a/integration-test/compiler/src/test/kotlin/com/uber/crumb/integration/compiler/GsonSupportTest.kt
+++ b/integration-test/compiler/src/test/kotlin/com/uber/crumb/integration/compiler/GsonSupportTest.kt
@@ -67,26 +67,29 @@ public abstract class MyAdapterFactory {
 
     val expected = JavaFileObjects.forSourceString("test.GsonProducer_MyAdapterFactory", """
 package test;
+
 import com.google.gson.Gson;
 import com.google.gson.TypeAdapter;
 import com.google.gson.TypeAdapterFactory;
 import com.google.gson.reflect.TypeToken;
 import java.lang.Override;
 import java.lang.SuppressWarnings;
+import javax.annotation.Nullable;
 
 final class GsonProducer_MyAdapterFactory implements TypeAdapterFactory {
-    @Override
-    @SuppressWarnings("unchecked")
-    public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
-        Class<T> rawType = (Class<T>) type.getRawType();
-        if (Foo.class.isAssignableFrom(rawType)) {
-            return (TypeAdapter<T>) Foo.typeAdapter(gson);
-        } else if (Bar.class.isAssignableFrom(rawType)) {
-            return (TypeAdapter<T>) Bar.jsonAdapter(gson);
-        } else {
-            return null;
-        }
+  @Nullable
+  @Override
+  @SuppressWarnings("unchecked")
+  public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+    Class<T> rawType = (Class<T>) type.getRawType();
+    if (Foo.class.isAssignableFrom(rawType)) {
+      return (TypeAdapter<T>) Foo.typeAdapter(gson);
+    } else if (Bar.class.isAssignableFrom(rawType)) {
+      return (TypeAdapter<T>) Bar.jsonAdapter(gson);
+    } else {
+      return null;
     }
+  }
 }""")
 
     assertAbout<JavaSourcesSubject, Iterable<JavaFileObject>>(javaSources())

--- a/integration-test/compiler/src/test/kotlin/com/uber/crumb/integration/compiler/MoshiSupportTest.kt
+++ b/integration-test/compiler/src/test/kotlin/com/uber/crumb/integration/compiler/MoshiSupportTest.kt
@@ -97,11 +97,12 @@ import java.lang.Override;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.Set;
+import javax.annotation.Nullable;
 
 final class MoshiProducer_MyAdapterFactory implements JsonAdapter.Factory {
-  @Override public JsonAdapter<?> create(Type type,
-          Set<? extends Annotation> annotations,
-          Moshi moshi) {
+  @Nullable
+  @Override
+  public JsonAdapter<?> create(Type type, Set<? extends Annotation> annotations, Moshi moshi) {
     if (!annotations.isEmpty()) return null;
     if (type.equals(Foo.class)) {
       return Foo.jsonAdapter(moshi);

--- a/integration-test/integration/build.gradle
+++ b/integration-test/integration/build.gradle
@@ -28,11 +28,18 @@ dependencies {
   api deps.misc.moshi
   annotationProcessor project(":crumb-compiler")
   annotationProcessor project(":integration-test:compiler")
+  annotationProcessor deps.apt.autoValue
+  annotationProcessor deps.apt.autoValueAnnotations
+  annotationProcessor deps.apt.autoValueGson
+  annotationProcessor deps.apt.autoValueMoshi
   api project(":crumb-annotations")
   api project(":integration-test:lib1")
   api project(":integration-test:lib2")
   api project(":integration-test:lib3")
   api project(":integration-test:annotations")
+  compileOnly deps.misc.javaxExtras
+  compileOnly deps.apt.autoValueAnnotations
+  implementation deps.apt.autoValueGsonRuntime
 
   testImplementation deps.test.truth
 

--- a/integration-test/integration/src/main/java/com/uber/crumb/integration/localmodels/LocalEnum.java
+++ b/integration-test/integration/src/main/java/com/uber/crumb/integration/localmodels/LocalEnum.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2019. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.crumb.integration.localmodels;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.Moshi;
+import com.squareup.moshi.Types;
+import com.uber.crumb.annotations.CrumbConsumable;
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Set;
+import javax.annotation.Nullable;
+
+@CrumbConsumable
+public enum LocalEnum {
+  FOO;
+
+  public static TypeAdapter<LocalEnum> typeAdapter() {
+    return new TypeAdapter<LocalEnum>() {
+      @Override
+      public void write(JsonWriter out, LocalEnum value) throws IOException {
+        out.value(value.name().toLowerCase());
+      }
+
+      @Override
+      public LocalEnum read(JsonReader in) throws IOException {
+        return LocalEnum.valueOf(in.nextString().toUpperCase());
+      }
+    };
+  }
+
+  public static JsonAdapter.Factory jsonAdapter() {
+    return new JsonAdapter.Factory() {
+      @Nullable
+      @Override
+      public JsonAdapter<?> create(Type type, Set<? extends Annotation> annotations, Moshi moshi) {
+        Class<?> rawType = Types.getRawType(type);
+        if (rawType.isAssignableFrom(LocalEnum.class)) {
+          return new JsonAdapter<LocalEnum>() {
+            @Override
+            public LocalEnum fromJson(com.squareup.moshi.JsonReader reader) throws IOException {
+              return LocalEnum.valueOf(reader.nextString().toUpperCase());
+            }
+
+            @Override
+            public void toJson(com.squareup.moshi.JsonWriter writer, LocalEnum value)
+                throws IOException {
+              writer.value(value.name().toLowerCase());
+            }
+          };
+        }
+        return null;
+      }
+    };
+  }
+}

--- a/integration-test/integration/src/main/java/com/uber/crumb/integration/localmodels/LocalModel.java
+++ b/integration-test/integration/src/main/java/com/uber/crumb/integration/localmodels/LocalModel.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.crumb.integration.localmodels;
+
+import com.google.auto.value.AutoValue;
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.Moshi;
+import com.uber.crumb.annotations.CrumbConsumable;
+
+@AutoValue
+@CrumbConsumable
+public abstract class LocalModel {
+
+  abstract String foo();
+
+  public static TypeAdapter<LocalModel> typeAdapter(Gson gson) {
+    return new AutoValue_LocalModel.GsonTypeAdapter(gson);
+  }
+
+  public static JsonAdapter<LocalModel> jsonAdapter(Moshi moshi) {
+    return new AutoValue_LocalModel.MoshiJsonAdapter(moshi);
+  }
+
+  public static LocalModel create(String foo) {
+    return new AutoValue_LocalModel(foo);
+  }
+}

--- a/integration-test/integration/src/main/java/com/uber/crumb/integration/localmodels/LocalProducer.java
+++ b/integration-test/integration/src/main/java/com/uber/crumb/integration/localmodels/LocalProducer.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.crumb.integration.localmodels;
+
+import com.google.gson.TypeAdapterFactory;
+import com.squareup.moshi.JsonAdapter;
+import com.uber.crumb.integration.annotations.GsonFactory;
+import com.uber.crumb.integration.annotations.MoshiFactory;
+
+@GsonFactory(GsonFactory.Type.PRODUCER)
+@MoshiFactory(MoshiFactory.Type.PRODUCER)
+public abstract class LocalProducer {
+
+  public static TypeAdapterFactory gson() {
+    return new GsonProducer_LocalProducer();
+  }
+
+  public static JsonAdapter.Factory moshi() {
+    return new MoshiProducer_LocalProducer();
+  }
+}

--- a/integration-test/integration/src/test/java/com/uber/crumb/integration/consumer/IntegrationConsumerTest.java
+++ b/integration-test/integration/src/test/java/com/uber/crumb/integration/consumer/IntegrationConsumerTest.java
@@ -38,9 +38,13 @@ public final class IntegrationConsumerTest {
   // output keys in the same
   // order.
   private static final String EXPECTED_GSON_JSON =
-      "{\"lib1Model\":{\"foo\":\"lib1Model\"},\"lib1Enum\":\"foo\",\"lib2Model\":{\"foo\":\"lib2Model\"},\"lib2Enum\":\"foo\",\"lib3Model\":{\"foo\":\"lib3Model\"},\"lib3Enum\":\"foo\",\"localModel\":{\"foo\":\"localModel\"},\"localEnum\":\"foo\"}";
+      "{\"lib1Model\":{\"foo\":\"lib1Model\"},\"lib1Enum\":\"foo\",\"lib2Model\":{\"foo\":"
+          + "\"lib2Model\"},\"lib2Enum\":\"foo\",\"lib3Model\":{\"foo\":\"lib3Model\"},"
+          + "\"lib3Enum\":\"foo\",\"localModel\":{\"foo\":\"localModel\"},\"localEnum\":\"foo\"}";
   private static final String EXPECTED_MOSHI_JSON =
-      "{\"lib1Enum\":\"foo\",\"lib1Model\":{\"foo\":\"lib1Model\"},\"lib2Enum\":\"foo\",\"lib2Model\":{\"foo\":\"lib2Model\"},\"lib3Enum\":\"foo\",\"lib3Model\":{\"foo\":\"lib3Model\"},\"localEnum\":\"foo\",\"localModel\":{\"foo\":\"localModel\"}}";
+      "{\"lib1Enum\":\"foo\",\"lib1Model\":{\"foo\":\"lib1Model\"},\"lib2Enum\":\"foo\","
+          + "\"lib2Model\":{\"foo\":\"lib2Model\"},\"lib3Enum\":\"foo\",\"lib3Model\":{\"foo\":"
+          + "\"lib3Model\"},\"localEnum\":\"foo\",\"localModel\":{\"foo\":\"localModel\"}}";
 
   private final Gson gson =
       new GsonBuilder().registerTypeAdapterFactory(IntegrationConsumer.gson()).create();

--- a/integration-test/integration/src/test/java/com/uber/crumb/integration/consumer/IntegrationConsumerTest.java
+++ b/integration-test/integration/src/test/java/com/uber/crumb/integration/consumer/IntegrationConsumerTest.java
@@ -24,6 +24,8 @@ import com.uber.crumb.integration.lib2.Lib2Enum;
 import com.uber.crumb.integration.lib2.Lib2Model;
 import com.uber.crumb.integration.lib3.Lib3Enum;
 import com.uber.crumb.integration.lib3.Lib3Model;
+import com.uber.crumb.integration.localmodels.LocalEnum;
+import com.uber.crumb.integration.localmodels.LocalModel;
 import java.io.IOException;
 import org.junit.Test;
 
@@ -36,13 +38,9 @@ public final class IntegrationConsumerTest {
   // output keys in the same
   // order.
   private static final String EXPECTED_GSON_JSON =
-      "{\"lib1Model\":{\"foo\":\"lib1Model\"},"
-          + "\"lib1Enum\":\"foo\",\"lib2Model\":{\"foo\":\"lib2Model\"},\"lib2Enum\":"
-          + "\"foo\",\"lib3Model\":{\"foo\":\"lib3Model\"},\"lib3Enum\":\"foo\"}";
+      "{\"lib1Model\":{\"foo\":\"lib1Model\"},\"lib1Enum\":\"foo\",\"lib2Model\":{\"foo\":\"lib2Model\"},\"lib2Enum\":\"foo\",\"lib3Model\":{\"foo\":\"lib3Model\"},\"lib3Enum\":\"foo\",\"localModel\":{\"foo\":\"localModel\"},\"localEnum\":\"foo\"}";
   private static final String EXPECTED_MOSHI_JSON =
-      "{\"lib1Enum\":\"foo\",\"lib1Model\""
-          + ":{\"foo\":\"lib1Model\"},\"lib2Enum\":\"foo\",\"lib2Model\":{\"foo\":\"lib2Model\"}"
-          + ",\"lib3Enum\":\"foo\",\"lib3Model\":{\"foo\":\"lib3Model\"}}";
+      "{\"lib1Enum\":\"foo\",\"lib1Model\":{\"foo\":\"lib1Model\"},\"lib2Enum\":\"foo\",\"lib2Model\":{\"foo\":\"lib2Model\"},\"lib3Enum\":\"foo\",\"lib3Model\":{\"foo\":\"lib3Model\"},\"localEnum\":\"foo\",\"localModel\":{\"foo\":\"localModel\"}}";
 
   private final Gson gson =
       new GsonBuilder().registerTypeAdapterFactory(IntegrationConsumer.gson()).create();
@@ -58,7 +56,9 @@ public final class IntegrationConsumerTest {
             Lib2Model.create("lib2Model"),
             Lib2Enum.FOO,
             Lib3Model.create("lib3Model"),
-            Lib3Enum.FOO);
+            Lib3Enum.FOO,
+            LocalModel.create("localModel"),
+            LocalEnum.FOO);
 
     String json = gson.toJson(data);
     assertThat(json).isEqualTo(EXPECTED_GSON_JSON);
@@ -79,7 +79,9 @@ public final class IntegrationConsumerTest {
             Lib2Model.create("lib2Model"),
             Lib2Enum.FOO,
             Lib3Model.create("lib3Model"),
-            Lib3Enum.FOO);
+            Lib3Enum.FOO,
+            LocalModel.create("localModel"),
+            LocalEnum.FOO);
 
     String json = moshi.adapter(TestData.class).toJson(data);
     assertThat(json).isEqualTo(EXPECTED_MOSHI_JSON);
@@ -105,20 +107,25 @@ public final class IntegrationConsumerTest {
     public final Lib2Enum lib2Enum;
     public final Lib3Model lib3Model;
     public final Lib3Enum lib3Enum;
+    public final LocalModel localModel;
+    public final LocalEnum localEnum;
 
-    public TestData(
-        Lib1Model lib1Model,
+    public TestData(Lib1Model lib1Model,
         Lib1Enum lib1Enum,
         Lib2Model lib2Model,
         Lib2Enum lib2Enum,
         Lib3Model lib3Model,
-        Lib3Enum lib3Enum) {
+        Lib3Enum lib3Enum,
+        LocalModel localModel,
+        LocalEnum localEnum) {
       this.lib1Model = lib1Model;
       this.lib1Enum = lib1Enum;
       this.lib2Model = lib2Model;
       this.lib2Enum = lib2Enum;
       this.lib3Model = lib3Model;
       this.lib3Enum = lib3Enum;
+      this.localModel = localModel;
+      this.localEnum = localEnum;
     }
 
     @Override
@@ -147,7 +154,13 @@ public final class IntegrationConsumerTest {
       if (!lib3Model.equals(testData.lib3Model)) {
         return false;
       }
-      return lib3Enum == testData.lib3Enum;
+      if (lib3Enum != testData.lib3Enum) {
+        return false;
+      }
+      if (!localModel.equals(testData.localModel)) {
+        return false;
+      }
+      return localEnum == testData.localEnum;
     }
 
     @Override
@@ -158,6 +171,8 @@ public final class IntegrationConsumerTest {
       result = 31 * result + lib2Enum.hashCode();
       result = 31 * result + lib3Model.hashCode();
       result = 31 * result + lib3Enum.hashCode();
+      result = 31 * result + localModel.hashCode();
+      result = 31 * result + localEnum.hashCode();
       return result;
     }
   }

--- a/sample/plugins-compiler/android/java/app/src/main/java/com/uber/crumb/sample/DefaultTranslations.java
+++ b/sample/plugins-compiler/android/java/app/src/main/java/com/uber/crumb/sample/DefaultTranslations.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.crumb.sample;
+
+import com.uber.crumb.sample.pluginscompiler.annotations.Plugin;
+
+@Plugin
+public class DefaultTranslations implements Translations {
+
+  @Override
+  public String translationForKey(String key) {
+    return "foo";
+  }
+}

--- a/sample/plugins-compiler/android/kotlin/app/src/main/kotlin/com/uber/crumb/sample/DefaultTranslations.kt
+++ b/sample/plugins-compiler/android/kotlin/app/src/main/kotlin/com/uber/crumb/sample/DefaultTranslations.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.crumb.sample
+
+import com.uber.crumb.sample.pluginscompiler.annotations.Plugin
+
+@Plugin
+class DefaultTranslations : Translations {
+
+  override fun translationForKey(key: String): String {
+    return "foo"
+  }
+}

--- a/sample/plugins-compiler/jvm/java/app/src/main/java/com/uber/crumb/sample/DefaultTranslations.java
+++ b/sample/plugins-compiler/jvm/java/app/src/main/java/com/uber/crumb/sample/DefaultTranslations.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.crumb.sample;
+
+import com.uber.crumb.sample.pluginscompiler.annotations.Plugin;
+
+@Plugin
+public class DefaultTranslations implements Translations {
+
+  @Override
+  public String translationForKey(String key) {
+    return "foo";
+  }
+}

--- a/sample/plugins-compiler/jvm/kotlin/app/src/main/kotlin/com/uber/crumb/sample/DefaultTranslations.kt
+++ b/sample/plugins-compiler/jvm/kotlin/app/src/main/kotlin/com/uber/crumb/sample/DefaultTranslations.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.crumb.sample
+
+import com.uber.crumb.sample.pluginscompiler.annotations.Plugin
+
+@Plugin
+class DefaultTranslations : Translations {
+
+  override fun translationForKey(key: String): String {
+    return "foo"
+  }
+}


### PR DESCRIPTION
This allows consumers to consume models generated by producers in the same compilation path. Ended up being surprisingly simple as well! Resolves #48