### PR TITLE
Fix crumb-compiler dependencies

### DIFF
--- a/crumb-compiler/build.gradle
+++ b/crumb-compiler/build.gradle
@@ -49,13 +49,13 @@ dependencies {
   kapt deps.apt.incapProcessor
   compileOnly deps.apt.autoServiceAnnotations
 
-  implementation project(":crumb-annotations")
-  implementation project(":crumb-core")
-  implementation project(':crumb-compiler-api')
-  implementation deps.apt.incap
-  implementation deps.misc.okio
-  implementation deps.apt.autoCommon
-  implementation deps.kotlin.stdLibJdk8
+  api project(":crumb-annotations")
+  api project(":crumb-core")
+  api project(':crumb-compiler-api')
+  api deps.apt.incap
+  api deps.misc.okio
+  api deps.apt.autoCommon
+  api deps.kotlin.stdLibJdk8
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/crumb-compiler/build.gradle
+++ b/crumb-compiler/build.gradle
@@ -49,17 +49,13 @@ dependencies {
   kapt deps.apt.incapProcessor
   compileOnly deps.apt.autoServiceAnnotations
 
-  api deps.apt.incap
-  api deps.misc.moshi
-  compileOnly deps.apt.autoServiceAnnotations
-
-  api project(":crumb-core")
-  api project(':crumb-compiler-api')
+  implementation project(":crumb-annotations")
+  implementation project(":crumb-core")
+  implementation project(':crumb-compiler-api')
+  implementation deps.apt.incap
   implementation deps.misc.okio
-
   implementation deps.apt.autoCommon
   implementation deps.kotlin.stdLibJdk8
-  implementation project(":crumb-annotations")
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/crumb-compiler/build.gradle
+++ b/crumb-compiler/build.gradle
@@ -53,9 +53,9 @@ dependencies {
   api project(":crumb-core")
   api project(':crumb-compiler-api')
   api deps.apt.incap
-  api deps.misc.okio
-  api deps.apt.autoCommon
-  api deps.kotlin.stdLibJdk8
+  implementation deps.misc.okio
+  implementation deps.apt.autoCommon
+  implementation deps.kotlin.stdLibJdk8
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')


### PR DESCRIPTION
None of these need to be `api` since it's a top-level dependency, also removes the moshi and duplicate autoservice deps