### PR TITLE
Tighten generated kotlin index files

### DIFF
--- a/crumb-core/src/main/kotlin/com/uber/crumb/core/CrumbOutputLanguage.kt
+++ b/crumb-core/src/main/kotlin/com/uber/crumb/core/CrumbOutputLanguage.kt
@@ -96,7 +96,7 @@ enum class CrumbOutputLanguage {
               .build()
           FileSpec.builder(packageName, "-$fileName")
               .addComment(GENERATED_COMMENT)
-              .addAnnotation(com.squareup.kotlinpoet.AnnotationSpec.builder(JvmName::class)
+              .addAnnotation(KotlinAnnotationSpec.builder(JvmName::class)
                   .addMember("name = %S", "-$fileName")
                   .useSiteTarget(FILE)
                   .build())


### PR DESCRIPTION
This tightens Kotlin index files to be private, non-instantiable classes with names not visible from java. Saves an instance allocation and also further prevents possible usage from Java.

Now a class looks like this:

```kotlin
// Generated, do not modify!
@file:JvmName(name = "-EnglishTranslationsCrumbIndex")

package com.uber.crumb.indices

import com.uber.crumb.annotations.internal.CrumbIndex
import kotlin.jvm.JvmName

/**
 * This type + annotation exists for sharing information to the Crumb annotation processor and
 * should not be considered public API.
 */
@CrumbIndex(value =
    [31,-117,8,0,0,0,0,0,0,0,-29,-46,76,-50,-49,-43,43,77,74,45,-46,75,46,42,-51,77,-46,43,78,-52,45,-56,73,-43,115,-51,75,-49,-55,44,-50,8,41,74,-52,43,-50,73,44,-55,-52,-49,43,22,-14,-25,-30,15,-56,41,77,-49,-52,43,118,-50,-49,45,-56,-52,73,45,18,-78,-63,20,34,-34,64,0,-46,-61,89,127,124,0,0,0])
private class EnglishTranslationsCrumbIndex private constructor()

```